### PR TITLE
Allow turning symbols off on UTF-8 platforms

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -13,10 +13,8 @@ strrep <- function(x, ...) {
 
 fancy_boxes <- function() {
   # We don't always have all symbols even on Unicode platforms
-  # (example: LaTeX output).  This is why we need to make this
-  # fully configurable, the platform info is used as a default
-  # setting in .onLoad().
-  isTRUE(getOption("cli.unicode"))
+  # (example: LaTeX output).
+  isTRUE(getOption("cli.unicode", default = l10n_info()$`UTF-8`))
 }
 
 apply_style <- function(text, style, bg = FALSE) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,11 @@ strrep <- function(x, ...) {
 }
 
 fancy_boxes <- function() {
-  isTRUE(getOption("cli.unicode")) || l10n_info()$`UTF-8`
+  # We don't always have all symbols even on Unicode platforms
+  # (example: LaTeX output).  This is why we need to make this
+  # fully configurable, the platform info is used as a default
+  # setting in .onLoad().
+  isTRUE(getOption("cli.unicode"))
 }
 
 apply_style <- function(text, style, bg = FALSE) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,0 @@
-.onLoad <- function(lib, pkg) {
-  if (is.null(getOption("cli.symbols"))) {
-    options(cli.symbols = l10n_info()$`UTF-8`)
-  }
-}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,5 @@
+.onLoad <- function(lib, pkg) {
+  if (is.null(getOption("cli.symbols"))) {
+    options(cli.symbols = l10n_info()$`UTF-8`)
+  }
+}


### PR DESCRIPTION
Related: #27.

I'm not sure this is the best way to do this, but the original code didn't support turning it off at all (short of setting `LC_CTYPE = "C"`).