### PR TITLE
fixed "C stack usage" error caused by loops in trees

### DIFF
--- a/R/tree.R
+++ b/R/tree.R
@@ -67,7 +67,7 @@ tree <- function(data, root = data[[1]][[1]], style = NULL,
   labels <- if (ncol(data) >= 3) data[[3]] else data[[1]]
   res <- character()
 
-  pt <- function(root, n = integer(), mx = integer()) {
+  pt <- function(root, n = integer(), mx = integer(), used = character()) {
 
     num_root <- match(root, data[[1]])
 
@@ -88,9 +88,15 @@ tree <- function(data, root = data[[1]][[1]], style = NULL,
 
     res <<- c(res, paste0(paste(prefix, collapse = ""), labels[[num_root]]))
 
-    children <- data[[2]][[num_root]]
-    for (d in seq_along(children)) {
-      pt(children[[d]], c(n, d), c(mx, length(children)))
+    if (root %in% used) {
+      warning(call. = FALSE,
+              "Endless loop found in tree: ",
+              paste0(c(used, root), collapse = " -> "))
+    } else {
+      children <- data[[2]][[num_root]]
+      for (d in seq_along(children)) {
+        pt(children[[d]], c(n, d), c(mx, length(children)), c(used, root))
+      }
     }
   }
 

--- a/tests/testthat/test-tree.R
+++ b/tests/testthat/test-tree.R
@@ -40,4 +40,24 @@ test_that("tree", {
     "└─rprojroot",
     "  └─backports")
   expect_equal(out, exp)
+
+  # Check that trees with apparent circularity error nicely
+  data <- data.frame(
+    stringsAsFactors = FALSE,
+    X = c("a", "b", "c","d", "e", "f", "g", "h", "j"),
+    Y = I(list(
+      c("b", "e", "f"),
+      c("d", "g"),
+      character(0),
+      c("a", "h"),
+      character(0),
+      character(0),
+      character(0),
+      c("j"),
+      character(0)
+    ))
+  )
+
+  expect_warning(tree(data), "Endless loop found in tree: a -> b -> d -> a")
+
 })


### PR DESCRIPTION
I noticed this error happens when there is loops in trees:

```r
> source("https://install-github.me/r-lib/cli")
> library(cli)
> data <- data.frame(
+   stringsAsFactors = FALSE,
+   X = c("a", "b", "c","d", "e", "f", "g", "h", "j"),
+   Y = I(list(
+     c("b", "e", "f"),
+     c("d", "g"),
+     character(0),
+     c("a", "h"),
+     character(0),
+     character(0),
+     character(0),
+     c("j"),
+     character(0)
+   ))
+ )
> tree(data)
Error: C stack usage  7970300 is too close to the limit
```

I fixed, so this happens instead:

```r
> source("https://install-github.me/zachary-foster/cli")
> library(cli)
> data <- data.frame(
+   stringsAsFactors = FALSE,
+   X = c("a", "b", "c","d", "e", "f", "g", "h", "j"),
+   Y = I(list(
+     c("b", "e", "f"),
+     c("d", "g"),
+     character(0),
+     c("a", "h"),
+     character(0),
+     character(0),
+     character(0),
+     c("j"),
+     character(0)
+   ))
+ )
> tree(data)
a
├─b
│ ├─d
│ │ ├─a
│ │ └─h
│ │   └─j
│ └─g
├─e
└─f
Warning message:
Endless loop found in tree: a -> b -> d -> a 
```

The "loops" in the data I was using were not actually loops, but taxonomic lineages with the same name repeated. EG:

```r
├─Tenericutes
│ ├─Erysipelotrichi
│ └─Mollicutes
└─Spirochaetes
  └─Spirochaetes
Warning messages:
1: Endless loop found in tree: Root -> Actinobacteria -> Actinobacteria 
2: Endless loop found in tree: Root -> Fusobacteria -> Fusobacteria 
3: Endless loop found in tree: Root -> Spirochaetes -> Spirochaetes 
```

So the first column in the data.frame given to `tree` had multiple "Spirochaetes" entires, but each one was actually a different taxon. I tried to find a way to make `tree` understand this, but the I think the way the input data is structured makes it impossible to figure out which "Spirochaetes" is being referred to, so the warning is the best I came up with.

Cool package! I plan on using it to print taxonomic trees in one of my packages. 