### PR TITLE
Fix a trivial typo in is_utf8_output documentation

### DIFF
--- a/R/utf8.R
+++ b/R/utf8.R
@@ -2,7 +2,7 @@
 #' Whether cli is emitting UTF-8 characters
 #'
 #' UTF-8 cli characters can be turned on by setting the `cli.unicode`
-#' option to `TRUE`. They can be turned on by setting if to `FALSE`.
+#' option to `TRUE`. They can be turned off by setting if to `FALSE`.
 #' If this option is not set, then [base::l10n_info()] is used to detect
 #' UTF-8 support.
 #'


### PR DESCRIPTION
Change `on` -> `off` for the case of `cli.unicode == FALSE`