### PR TITLE
Better status bar update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 * cli now works better with wide Unicode characters, for example emojis.
   In particular, a status bar containing emojis is cleared properly (#133).
 
+* The status bar now does now flicker when updated, in terminals (#135).
+
 # cli 2.0.1
 
 * Symbols (`symbol$*`) are now correctly printed in RStudio on Windows (#124).

--- a/R/internals.R
+++ b/R/internals.R
@@ -60,11 +60,7 @@ clii__vspace <- function(app, n) {
   }
 }
 
-clii__message <- function(..., domain = NULL, appendLF = TRUE,
-                          output = stderr()) {
-
-  msg <- .makeMessage(..., domain = domain, appendLF = appendLF)
-
+get_real_output <- function(output) {
   if (! inherits(output, "connection")) {
     output <- switch(
       output,
@@ -74,6 +70,14 @@ clii__message <- function(..., domain = NULL, appendLF = TRUE,
       "stdout" = stdout()
     )
   }
+  output
+}
+
+clii__message <- function(..., domain = NULL, appendLF = TRUE,
+                          output = stderr()) {
+
+  msg <- .makeMessage(..., domain = domain, appendLF = appendLF)
+  output <- get_real_output(output)
 
   withRestarts(muffleMessage = function() NULL, {
     signalCondition(simpleMessage(msg))

--- a/R/tty.R
+++ b/R/tty.R
@@ -131,6 +131,7 @@ is_dynamic_tty <- function(stream = cli_output_connection()) {
 ANSI_ESC <- "\u001B["
 ANSI_HIDE_CURSOR <- paste0(ANSI_ESC, "?25l")
 ANSI_SHOW_CURSOR <- paste0(ANSI_ESC, "?25h")
+ANSI_EL <- paste0(ANSI_ESC, "K")
 
 #' Detect if a stream support ANSI escape characters
 #'
@@ -152,6 +153,14 @@ ANSI_SHOW_CURSOR <- paste0(ANSI_ESC, "?25h")
 #' is_ansi_tty()
 
 is_ansi_tty <- function(stream = stderr()) {
+  # Option takes precedence
+  opt <- getOption("cli.ansi")
+  if (isTRUE(opt)) {
+    return(TRUE)
+  } else if (identical(opt, FALSE)) {
+    return(FALSE)
+  }
+
   # RStudio is handled separately
   if (rstudio$detect()[["ansi_tty"]] && is_stdx(stream)) return(TRUE)
 

--- a/man/cli_process_start.Rd
+++ b/man/cli_process_start.Rd
@@ -35,7 +35,7 @@ cli_process_failed(
 }
 \arguments{
 \item{msg}{The message to show to indicate the start of the process or
-compuration. It will be collapsed into a single string, and the first
+computation. It will be collapsed into a single string, and the first
 line is kept and cut to \code{\link[=console_width]{console_width()}}.}
 
 \item{msg_done}{The message to use for successful termination.}
@@ -44,7 +44,7 @@ line is kept and cut to \code{\link[=console_width]{console_width()}}.}
 
 \item{on_exit}{Whether this process should fail or terminate
 successfully when the calling function (or the environment in \code{.envir})
-exits.x}
+exits.}
 
 \item{msg_class}{The style class to add to the message. Use an empty
 string to suppress styling.}
@@ -73,7 +73,7 @@ Id of the status bar container.
 \description{
 Typically you call \code{cli_process_start()} to start the process, and then
 \code{cli_process_done()} when it is done. If an error happens before
-\code{cli_process_fone()} is called, then cli automatically shows the message
+\code{cli_process_done()} is called, then cli automatically shows the message
 for unsuccessful termination.
 }
 \details{

--- a/man/cli_status.Rd
+++ b/man/cli_status.Rd
@@ -60,25 +60,10 @@ downloading a large file, so it sets the status bar accordingly. Once the
 download is done (or failed), the app typically updates the status bar
 again. cli automates much of this, via the \code{msg_done}, \code{msg_failed}, and
 \code{.auto_result} arguments. See examples below.
-\itemize{
-\item \code{foo}: Often status messages are associated with processes. E.g. the app starts
-downloading a large file, so it sets the status bar accordingly. Once the
-\item \code{bar}: short one
-\item \verb{another one}: Often status messages are associated with processes. E.g. the app starts
-downloading a large file, so it sets the status bar accordingly. Once the
-}
-
-\describe{
-\item{\code{foo}:}{Often status messages are associated with processes. E.g. the app starts
-downloading a large file, so it sets the status bar accordingly. Once the}
-\item{\code{bar}:}{short one}
-\item{\code{another one}:}{Often status messages are associated with processes. E.g. the app starts
-downloading a large file, so it sets the status bar accordingly. Once the}
-}
 }
 \seealso{
 \link{cli_process_start} for a higher level interface to the
-startus bar, that adds automatic styling.
+status bar, that adds automatic styling.
 
 Other status bar: 
 \code{\link{cli_process_start}()},

--- a/man/containers.Rd
+++ b/man/containers.Rd
@@ -11,8 +11,8 @@ containers as well: \code{\link[=cli_li]{cli_li()}}.
 }
 \details{
 Container elements need to be closed with \code{\link[=cli_end]{cli_end()}}. For convenience,
-they are have an \code{.auto_close} argument, which allows automatically
-closing a container element, when the function that created it
+they have an \code{.auto_close} argument, which instructs the container
+element to be closed automatically when the function that created it
 terminates (either regularly, or with an error).
 }
 \examples{

--- a/tests/testthat/test-status-bar.R
+++ b/tests/testthat/test-status-bar.R
@@ -16,6 +16,7 @@ test_that("create and clear", {
 })
 
 test_that("output while status bar is active", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1")
@@ -25,13 +26,14 @@ test_that("output while status bar is active", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rout2\nstatus1",
-    "\r       \rstatus2",
+    "\rstatus2",
     "\r       \r"))
 })
 
 test_that("interpolation", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_div(theme = list("span.pkg" = list("before" = "{", after = "}")))
     cli_status("You see 1+1={1+1}, this is {.pkg cli}")
@@ -39,11 +41,12 @@ test_that("interpolation", {
   }
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
-    "\r\rYou see 1+1=2, this is {cli}",
+    "\rYou see 1+1=2, this is {cli}",
     "\r                            \r"))
 })
 
 test_that("update", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1")
@@ -52,21 +55,23 @@ test_that("update", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
-    "\r       \rstatus2",
+    "\rstatus1",
+    "\rstatus2",
     "\r       \r"))
 })
 
 test_that("keep", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_status("* This is the current status", .keep = TRUE)
     cli_status_clear()
   }
   out <- crayon::strip_style(capt0(f()))
-  expect_equal(out, "\r\r* This is the current status\n")
+  expect_equal(out, "\r* This is the current status\n")
 })
 
 test_that("multiple status bars", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     sb1 <- cli_status("status1")
     cli_text("text1")
@@ -77,9 +82,9 @@ test_that("multiple status bars", {
   }
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rtext1\nstatus1",        # emit text1, restore status1
-    "\r       \rstatus2",               # show status2
+    "\rstatus2",                        # show status2
     "\r       \rtext2\nstatus2",        # emit text2, restore status2
     "\r       \rstatus1",               # clear status2, restore status1
     "\r       \rtext3\nstatus1",        # emit text3, restore status1
@@ -87,6 +92,7 @@ test_that("multiple status bars", {
 })
 
 test_that("truncating", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     withr::local_options(list(cli.width = 40))
     txt <- "Eiusmod enim mollit aute aliquip Lorem sunt cupidatat."
@@ -94,11 +100,12 @@ test_that("truncating", {
   }
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
-    "\r\rEiusmod enim mollit aute aliquip Lorem ",
+    "\rEiusmod enim mollit aute aliquip Lorem ",
     "\r                                       \r"))
 })
 
 test_that("ansi colors and clearing", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     withr::local_options(list(crayon.enabled = TRUE, crayon.colors = 256))
     crayon::num_colors(forget = TRUE)
@@ -123,6 +130,7 @@ test_that("theming status bar", {
 })
 
 test_that("successful termination", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1")
@@ -132,13 +140,14 @@ test_that("successful termination", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rout2\nstatus1",
-    "\r       \rstatus1 ... done\n"
+    "\rstatus1 ... done\n"
   ))
 })
 
 test_that("terminate with failed", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1")
@@ -148,13 +157,14 @@ test_that("terminate with failed", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rout2\nstatus1",
-    "\r       \rstatus1 ... failed\n"
+    "\rstatus1 ... failed\n"
   ))
 })
 
 test_that("auto close with success", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1", .auto_result = "done")
@@ -163,13 +173,14 @@ test_that("auto close with success", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rout2\nstatus1",
-    "\r       \rstatus1 ... done\n"
+    "\rstatus1 ... done\n"
   ))
 })
 
 test_that("auto close wtih failure", {
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("status1", .auto_result = "failed")
@@ -180,9 +191,9 @@ test_that("auto close wtih failure", {
   out <- crayon::strip_style(capt0(f()))
   expect_equal(out, paste0(
     "out1\n",
-    "\r\rstatus1",
+    "\rstatus1",
     "\r       \rout2\nstatus1",
-    "\r       \rstatus1 ... failed\n"
+    "\rstatus1 ... failed\n"
   ))
 })
 
@@ -253,6 +264,7 @@ test_that("Multiple spaces are no condensed in a status bar", {
 
 test_that("Emojis are cleaned up properly", {
   skip_on_os("windows")
+  withr::local_options(list(cli.ansi = FALSE))
   f <- function() {
     cli_text("out1")
     sb <- cli_status("\U0001F477")
@@ -263,15 +275,15 @@ test_that("Emojis are cleaned up properly", {
   exps <- c(
     paste0(
       "out1\n",
-      "\r\r\U0001F477",
+      "\r\U0001F477",
       "\r  \rout2\n\U0001F477",
-      "\r  \r\u2728",
+      "\r\u2728",
       "\r  \r"),
     paste0(
       "out1\n",
-      "\r\r<U+0001F477>",
+      "\r<U+0001F477>",
       "\r  \rout2\n<U+0001F477>",
-      "\r  \r<U+2728>",
+      "\r<U+2728>",
       "\r  \r")
   )
   expect_true(out %in% exps)


### PR DESCRIPTION
Use ANSI escape sequence to delete (part of) the line, instead of overwriting it with spaces, to reduce flickering. Closes #135.