### PR TITLE
Fix typos and semantic mistakes

### DIFF
--- a/man/chunks/pluralization.Rmd
+++ b/man/chunks/pluralization.Rmd
@@ -115,8 +115,8 @@ this may appear before or after the pluralization markup. If the message
 contains multiple `{}` substitutions _after_ pluralization markup, an
 error is thrown.
 
-Similarly, if the message contains no `{}` substituions at all, but
-has pluralization markup, and error is thrown.
+Similarly, if the message contains no `{}` substitutions at all, but
+has pluralization markup, an error is thrown.
 
 # Rules
 
@@ -144,12 +144,12 @@ pluralization quantity for all `{?}` markup in the message.
 cli uses the quantity of the `{}` substitution that precedes it.
 
 1. If a message has multiple `{}` substitutions and has pluralization
-markup with a preceding `{}` substitution, and error is thrown.
+markup without a preceding `{}` substitution, an error is thrown.
 
 ## Pluralization markup
 
-1. Pluralization markup start with `{?` and ends with `}`. It may not
-contain `{` and `}` characters, so it may not contains `{}` substitutions
+1. Pluralization markup starts with `{?` and ends with `}`. It may not
+contain `{` and `}` characters, so it may not contain `{}` substitutions
 either.
 
 1. Alternative words or suffixes are separated by `/`.
@@ -158,7 +158,7 @@ either.
    `quantity == 1` and this single alternative is used if `quantity != 1`.
 
 1. If there are two alternatives, the first one is used for `quantity == 1`,
-   the second one for `quantity != 1` (include 0).
+   the second one for `quantity != 1` (including ``quantity == 0`).
 
 1. If there are three alternatives, the first one is used for
-  `quantity == 0`, the second for `quantity == 1`, and the third otherwise.
+  `quantity == 0`, the second one for `quantity == 1`, and the third one otherwise.

--- a/vignettes/semantic-cli.Rmd
+++ b/vignettes/semantic-cli.Rmd
@@ -116,7 +116,7 @@ fun()
 If a paragraph (or other container, see 'Generic containers' later), is
 opened within a function, cli automatically closes it at the end of the
 function, by default. So in the previous example the last `cli_end()` call
-is not needed. Use `.auto_close = TRUE` in `cli_par()` to leave the
+is not needed. Use `.auto_close = FALSE` in `cli_par()` to leave the
 paragraph open after its calling function returns.
 
 ## Headings


### PR DESCRIPTION
Plus some other small improvements.

The semantic mistakes were in

- the last [pluralization quantity rule documentation](https://cli.r-lib.org/articles/pluralization.html#quantities)
- and in the [_Auto-closing containers_ documentation](https://cli.r-lib.org/articles/semantic-cli.html#auto-closing-containers)