### PR TITLE
Avoid default callr_message class, but use option

### DIFF
--- a/R/cli.R
+++ b/R/cli.R
@@ -511,14 +511,18 @@ cli__message <- function(type, args, .auto_close = TRUE, .envir = NULL) {
 
   cond <- list(message = paste("cli message", type),
                type = type, args = args, pid = clienv$pid)
-  class(cond) <- c("cli_message", "callr_message", "condition")
+
+  class(cond) <- c(
+    getOption("cli.message_class"),
+    "cli_message",
+    "condition"
+  )
 
   withRestarts(
   {
     signalCondition(cond)
     cli__default_handler(cond)
   },
-  callr_message_handled = function() NULL,
   cli_message_handled = function() NULL)
 
   invisible(args$id)

--- a/tests/testthat/test-subprocess.R
+++ b/tests/testthat/test-subprocess.R
@@ -6,6 +6,7 @@ test_that("events are properly generated", {
   if (packageVersion("callr") < "3.0.0.9001") skip("Need newer callr")
 
   do <- function() {
+    options(cli.message_class = "callr_message")
     cli::cli_div()
     cli::cli_h1("title")
     cli::cli_text("text")
@@ -41,6 +42,7 @@ test_that("subprocess with default handler", {
   if (packageVersion("callr") < "3.0.0.9001") skip("Need newer callr")
 
   do <- function() {
+    options(cli.message_class = "callr_message")
     cli::cli_div()
     cli::cli_h1("title")
     cli::cli_text("text")
@@ -123,7 +125,6 @@ test_that("output in child process", {
   expect_equal(result$stderr, "")
   expect_identical(result$result, "foobar")
   expect_null(result$error)
-  lapply(msgs, expect_s3_class, "callr_message")
   str <- paste(vcapply(msgs, "[[", "message"), collapse = "")
   expect_true(crayon::has_style(str))
   expect_match(str, "Title")
@@ -135,6 +136,7 @@ test_that("output in child process", {
 test_that("substitution in child process", {
 
   do <- function() {
+    options(cli.message_class = "callr_message")
     cli::cli_text("This is process {Sys.getpid()}.")
   }
 

--- a/vignettes/semantic-cli.Rmd
+++ b/vignettes/semantic-cli.Rmd
@@ -474,12 +474,14 @@ suppressMessages(cli_text("Not shown"))
 # Subprocesses
 
 If `cli_*()` commands are invoked in a subprocess via
-`callr::r_session` (see https://callr.r-lib.org), then they are
-automatically copied to the main R process:
+`callr::r_session` (see https://callr.r-lib.org), and the
+`cli.message_class` option is set to `"callr_message"`, then cli messages
+are automatically copied to the main R process:
 
 ```{asciicast}
 rs <- callr::r_session$new()
 rs$run(function() {
+  options(cli.message_class = "callr_message")
   cli::cli_text("This is subprocess {.emph {Sys.getpid()}} from {.pkg callr}")
   Sys.getpid()
 })


### PR DESCRIPTION
Closes #181. Closes #157.