### PR TITLE
Publicize `transform`

### DIFF
--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -237,6 +237,9 @@ NULL
 #' the properties. See [builtin_theme()] and [simple_theme()] for examples.
 #'
 #' @section Formatter callbacks:
+#'
+#' <!-- This is where I think `transform` should also be mentioned? -->
+#'
 #' For flexibility, themes may also define formatter functions, with
 #' property name `fmt`. These will be called once the other styles are
 #' applied to an element. They are only called on elements that produce
@@ -274,7 +277,8 @@ NULL
 #' * `digits`: Number of digits after the decimal point for numeric inline
 #'   element of class `.val`.
 #' * `fmt`: Generic formatter function that takes an input text and returns
-#'   formatted text. Can be applied to most elements.
+#'   formatted text. Can be applied to most elements. If colors are in use,
+#'   the input text provided to `fmt` already includes ANSI sequences.
 #' * `font-style`: If `"italic"` then the text is printed as cursive.
 #' * `font-weight`: If `"bold"`, then the text is printed in boldface.
 #' * `line-type`: Line type for [cli_rule()].
@@ -288,9 +292,10 @@ NULL
 #' * `text-decoration`: If `"underline"`, then underlined text is created.
 #' * `text-exdent`: Amound of indentation from the second line of wrapped
 #'    text.
-#' * `transform`: A function to call on gluw substitutions, before
-#'   collapsing them.
-#' * `vec_last`: The last seperator when collapsing vectors.
+#' * `transform`: A function to call on glue substitutions, before
+#'   collapsing them. Note that `transform` is applied prior to
+#'   implementing color via ANSI sequences.
+#' * `vec_last`: The last separator when collapsing vectors.
 #' * `vec_sep`: The separator to use when collapsing vectors.
 #' * `vec_trunc`: Vectors longer than this will be truncated. Defaults to
 #'   100.

--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -237,9 +237,6 @@ NULL
 #' the properties. See [builtin_theme()] and [simple_theme()] for examples.
 #'
 #' @section Formatter callbacks:
-#'
-#' <!-- This is where I think `transform` should also be mentioned? -->
-#'
 #' For flexibility, themes may also define formatter functions, with
 #' property name `fmt`. These will be called once the other styles are
 #' applied to an element. They are only called on elements that produce

--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -63,7 +63,7 @@
 #' ## Highlighting weird-looking values
 #'
 #' Often it is useful to highlight a weird file or path name, e.g. one
-#' that starts or ends with space characters. The buildin theme does this
+#' that starts or ends with space characters. The built-in theme does this
 #' for `.file`, `.path` and `.email` by default. You can highlight
 #' any string inline by adding the `.q` class to it.
 #'
@@ -86,16 +86,16 @@
 #'
 #' @section Formatting values:
 #'
-#' The `val` inline class formats values. By default (c.f. the builtin
+#' The `val` inline class formats values. By default (c.f. the built-in
 #' theme), it calls the [cli_format()] generic function, with the current
 #' style as the argument. See [cli_format()] for examples.
 #'
 #' @section Escaping `{` and `}`:
 #'
 #' It might happen that you want to pass a string to `cli_*` functions,
-#' and you do not_ want command substitution in that string, because it
-#' might contain `}` and `{` characters. The simplest solution for this is
-#' referring to the string from a template:
+#' and you do _not_ want command substitution in that string, because it
+#' might contain `{` and `}` characters. The simplest solution for this is
+#' to refer to the string from a template:
 #'
 #' ```
 #' msg <- "Error in if (ncol(dat$y)) {: argument is of length zero"
@@ -207,7 +207,7 @@ NULL
 #' These form a stack, and the themes on the top of the stack take
 #' precedence, over themes in the bottom.
 #'
-#' 1. The cli package has a builtin theme. This is always active.
+#' 1. The cli package has a built-in theme. This is always active.
 #'    See [builtin_theme()].
 #' 2. When an app object is created via [start_app()], the caller can
 #'    specify a theme, that is added to theme stack. If no theme is
@@ -295,8 +295,8 @@ NULL
 #' * `vec_trunc`: Vectors longer than this will be truncated. Defaults to
 #'   100.
 #'
-#' More properties might be adder later. If you think that a properly is
-#' not applied properly to an alement, please open an issue about it in
+#' More properties might be added later. If you think that a property is
+#' not applied properly to an element, please open an issue about it in
 #' the cli issue tracker.
 #'
 #' @section Examples:

--- a/man/inline-markup.Rd
+++ b/man/inline-markup.Rd
@@ -63,7 +63,7 @@ using them, see the example below.
 \subsection{Highlighting weird-looking values}{
 
 Often it is useful to highlight a weird file or path name, e.g. one
-that starts or ends with space characters. The buildin theme does this
+that starts or ends with space characters. The built-in theme does this
 for \code{.file}, \code{.path} and \code{.email} by default. You can highlight
 any string inline by adding the \code{.q} class to it.
 
@@ -93,7 +93,7 @@ See examples below.
 \section{Formatting values}{
 
 
-The \code{val} inline class formats values. By default (c.f. the builtin
+The \code{val} inline class formats values. By default (c.f. the built-in
 theme), it calls the \code{\link[=cli_format]{cli_format()}} generic function, with the current
 style as the argument. See \code{\link[=cli_format]{cli_format()}} for examples.
 }
@@ -102,9 +102,9 @@ style as the argument. See \code{\link[=cli_format]{cli_format()}} for examples.
 
 
 It might happen that you want to pass a string to \verb{cli_*} functions,
-and you do not_ want command substitution in that string, because it
-might contain \verb{\}} and \verb{\{} characters. The simplest solution for this is
-referring to the string from a template:\preformatted{msg <- "Error in if (ncol(dat$y)) \{: argument is of length zero"
+and you do \emph{not} want command substitution in that string, because it
+might contain \verb{\{} and \verb{\}} characters. The simplest solution for this is
+to refer to the string from a template:\preformatted{msg <- "Error in if (ncol(dat$y)) \{: argument is of length zero"
 cli_alert_warning("\{msg\}")
 }
 

--- a/man/themes.Rd
+++ b/man/themes.Rd
@@ -15,7 +15,7 @@ The style of an element is calculated from themes from four sources.
 These form a stack, and the themes on the top of the stack take
 precedence, over themes in the bottom.
 \enumerate{
-\item The cli package has a builtin theme. This is always active.
+\item The cli package has a built-in theme. This is always active.
 See \code{\link[=builtin_theme]{builtin_theme()}}.
 \item When an app object is created via \code{\link[=start_app]{start_app()}}, the caller can
 specify a theme, that is added to theme stack. If no theme is
@@ -91,7 +91,8 @@ argument.
 \item \code{digits}: Number of digits after the decimal point for numeric inline
 element of class \code{.val}.
 \item \code{fmt}: Generic formatter function that takes an input text and returns
-formatted text. Can be applied to most elements.
+formatted text. Can be applied to most elements. If colors are in use,
+the input text provided to \code{fmt} already includes ANSI sequences.
 \item \code{font-style}: If \code{"italic"} then the text is printed as cursive.
 \item \code{font-weight}: If \code{"bold"}, then the text is printed in boldface.
 \item \code{line-type}: Line type for \code{\link[=cli_rule]{cli_rule()}}.
@@ -105,16 +106,17 @@ as the margins, but this might change later.
 \item \code{text-decoration}: If \code{"underline"}, then underlined text is created.
 \item \code{text-exdent}: Amound of indentation from the second line of wrapped
 text.
-\item \code{transform}: A function to call on gluw substitutions, before
-collapsing them.
-\item \code{vec_last}: The last seperator when collapsing vectors.
+\item \code{transform}: A function to call on glue substitutions, before
+collapsing them. Note that \code{transform} is applied prior to
+implementing color via ANSI sequences.
+\item \code{vec_last}: The last separator when collapsing vectors.
 \item \code{vec_sep}: The separator to use when collapsing vectors.
 \item \code{vec_trunc}: Vectors longer than this will be truncated. Defaults to
 100.
 }
 
-More properties might be adder later. If you think that a properly is
-not applied properly to an alement, please open an issue about it in
+More properties might be added later. If you think that a property is
+not applied properly to an element, please open an issue about it in
 the cli issue tracker.
 }
 


### PR DESCRIPTION
Closes #245 

*In general, it feels like the word "format" is very over-loaded in the cli documentation. This is a micro-move toward starting to make the sequence of steps from user's input to the emitted message more clear, but it would be good to keep taking other opportunities to tighten this up.*

This PR is incomplete, because I don't feel capable of describing exactly what `transform` does, but I'm pretty sure it's about as important for theme tweaking as `fmt` (???). So I just left a stub for this.