### PR TITLE
Fix win10_build detection if osVersion is NULL

### DIFF
--- a/R/num-ansi-colors.R
+++ b/R/num-ansi-colors.R
@@ -243,7 +243,7 @@ emacs_version <- function() {
 }
 
 win10_build <- function() {
-  os <- utils::sessionInfo()$running
+  os <- utils::sessionInfo()$running %||% ""
   if (!grepl("^Windows 10 ", os)) return(0L)
   mch <- re_match(os, "[(]build (?<build>[0-9]+)[)]")
   mch <- suppressWarnings(as.integer(mch))

--- a/tests/testthat/test-num-ansi-colors.R
+++ b/tests/testthat/test-num-ansi-colors.R
@@ -1,0 +1,19 @@
+test_that("win10_build works for different osVersion", {
+    mockery::stub(
+        win10_build, "utils::sessionInfo",
+        list(running = NULL)
+    )
+    expect_identical(win10_build(), 0L)
+
+    mockery::stub(
+        win10_build, "utils::sessionInfo",
+        list(running = "Debian GNU/Linux 11 (bullseye)")
+    )
+    expect_identical(win10_build(), 0L)
+
+    mockery::stub(
+        win10_build, "utils::sessionInfo",
+        list(running = "Windows 10 x64 (build 16299)")
+    )
+    expect_identical(win10_build(), 16299L)
+})


### PR DESCRIPTION
I tried running the `targets` package on a singularity container generated by `guix pack`.
Running `targets::tar_make` fails because `cli:::win10_build` throws the following error:
> if (grepl("^Windows 10 "), os)): argument is of length zero

`osVersion` is `NULL` on this container. According to `?osVersion` that is expected on *"bizarre platforms"*. `osVersion` is returned by `utils::sessionInfo()$running`. This PR fixes `win10_build` for `osVersion == NULL`.