### PR TITLE
Better cli timer defaults for dynamic terminals

### DIFF
--- a/R/onload.R
+++ b/R/onload.R
@@ -6,8 +6,8 @@ NULL
 
 dummy <- function() { }
 
-cli_timer_interactive <- 200L
-cli_timer_non_interactive <- 3000L
+cli_timer_dynamic <- 200L
+cli_timer_non_dynamic <- 3000L
 
 clienv <- new.env(parent = emptyenv())
 clienv$pid <- Sys.getpid()
@@ -42,9 +42,9 @@ task_callback <- NULL
   tt <- as.integer(Sys.getenv("CLI_TICK_TIME", NA_character_))
   if (is.na(tt)) {
     tt <- if (interactive() || is_dynamic_tty()) {
-      cli_timer_interactive
+      cli_timer_dynamic
     } else {
-      cli_timer_non_interactive
+      cli_timer_non_dynamic
     }
   }
 

--- a/R/onload.R
+++ b/R/onload.R
@@ -41,7 +41,7 @@ task_callback <- NULL
 
   tt <- as.integer(Sys.getenv("CLI_TICK_TIME", NA_character_))
   if (is.na(tt)) {
-    tt <- if (interactive()) {
+    tt <- if (interactive() || is_dynamic_tty()) {
       cli_timer_interactive
     } else {
       cli_timer_non_interactive

--- a/vignettes/progress-advanced.Rmd
+++ b/vignettes/progress-advanced.Rmd
@@ -82,16 +82,21 @@ creating a progress bar. (If the timer is not initialized, then
 
 # Non-interactive R sessions
 
-Non-interactive R sessions often do not have a dynamic terminal, so cli cannot
-create and update a status bar in the last row of the display. In this case cli
-simply prints every progress update as a new line to the screen.
+cli output is different if the terminal or platform is not _dynamic_, i.e.
+if it does not support the `\r` character to move the cursor to the
+beginning of the line without starting a new line. This often happens when
+R is running non-interactively and the standard error is redirected to a
+file. cli uses the `cli::is_dynamic_tty()` function to determine if the
+output supports `\r`.
 
-Frequently updating the progress in this fashion would produce a lot of noisy
-output, which is why cli falls back to using a slower timer update interval in
-this scenario. By default the cli timer signals every 
-`r cli:::cli_timer_non_interactive` milliseconds in a non-interactive session
-without a dynamic terminal, instead of `r cli:::cli_timer_interactive`
-milliseconds.
+On a non-dynamic terminal, cli simply prints progress updates as new
+lines to the screen. Frequently updating the progress in this fashion would
+produce a lot of output, so on non-dynamic terminals cli falls back to a
+slower timer update interval.
+
+By default the cli timer signals every `r cli:::cli_timer_non_dynamic`
+milliseconds in an R session without a dynamic terminal, instead
+of `r cli:::cli_timer_dynamic` milliseconds.
 
 <!-- TODO: example -->
 

--- a/vignettes/progress-advanced.Rmd
+++ b/vignettes/progress-advanced.Rmd
@@ -82,15 +82,16 @@ creating a progress bar. (If the timer is not initialized, then
 
 # Non-interactive R sessions
 
-Non-interactive R sessions typically have two differences to interactive
-ones. First, by default the cli timer signals every
-`r cli:::cli_timer_non_interactive` milliseconds, instead of
-`r cli:::cli_timer_interactive` milliseconds.
+Non-interactive R sessions often do not have a dynamic terminal, so cli cannot
+create and update a status bar in the last row of the display. In this case cli
+simply prints every progress update as a new line to the screen.
 
-Second, non-interactive sessions often do not have a dynamic terminal,
-so cli cannot create and update a status bar in the last row of the
-display. In this case cli simply prints every progress update as a new
-line to the screen.
+Frequently updating the progress in this fashion would produce a lot of noisy
+output, which is why cli falls back to using a slower timer update interval in
+this scenario. By default the cli timer signals every 
+`r cli:::cli_timer_non_interactive` milliseconds in a non-interactive session
+without a dynamic terminal, instead of `r cli:::cli_timer_interactive`
+milliseconds.
 
 <!-- TODO: example -->
 


### PR DESCRIPTION
Changed the non-interactive sessions with dynamic terminals to use the faster default cli timer interval for smoother animations. Updated the advanced progress bars vignette accordingly.

Closes #304 