### PR TITLE
Do not kill tick thread in ASAN

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -89,14 +89,20 @@ int cli__kill_thread() {
   return ret;
 }
 
+#ifndef __has_feature
+  #define __has_feature(x) 0
+#endif
+
 SEXP clic_stop_thread() {
   int ret = 1;
-#if defined(__has_feature)
+#if defined(__clang__) && defined(__has_feature)
 # if __has_feature(address_sanitizer)
-  /* do nothing */
+  /* clang in ASAN, do nothing */
 # else
   ret = cli__kill_thread();
-#endif
+# endif
+#else
+  ret = cli__kill_thread();
 #endif
   if (!ret) {
     R_ReleaseObject(cli_pkgenv);

--- a/src/thread.c
+++ b/src/thread.c
@@ -90,7 +90,14 @@ int cli__kill_thread() {
 }
 
 SEXP clic_stop_thread() {
-  int ret = cli__kill_thread();
+  int ret = 1;
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer)
+  /* do nothing */
+# else
+  ret = cli__kill_thread();
+#endif
+#endif
   if (!ret) {
     R_ReleaseObject(cli_pkgenv);
   }

--- a/tests/testthat/test-progress-c.R
+++ b/tests/testthat/test-progress-c.R
@@ -120,6 +120,9 @@ test_that("clic__find_var", {
 })
 
 test_that("unloading stops the thread", {
+  # It is important to skip this on CRAN, because in ASAN we do not
+  # kill the tick thread on unload, because it triggers an ASAN crash,
+  # which is similar to https://github.com/google/sanitizers/issues/1152
   skip_on_cran()
   fun <- function() {
     before <- ps::ps_num_threads()


### PR DESCRIPTION
Because it triggers some ASAN crash, that looks like this:

```
==3714024==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f1a756b2df0 at pc 0x00000048d102 bp 0x7f1a756b2dc0 sp 0x7f1a756b2588
WRITE of size 24 at 0x7f1a756b2df0 thread T16777215
    #0 0x48d101 in sigaltstack /data/gannet/ripley/Sources2/LLVM/12.0.0/llvm-project-12.0.0.src/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:9986:5
    #1 0x4cb06c in __sanitizer::UnsetAlternateSignalStack() /data/gannet/ripley/Sources2/LLVM/12.0.0/llvm-project-12.0.0.src/compiler-rt/lib/sanitizer_common/sanitizer_posix_libcdep.cpp:191:3
    #2 0x4b7608 in __asan::AsanThread::Destroy() /data/gannet/ripley/Sources2/LLVM/12.0.0/llvm-project-12.0.0.src/compiler-rt/lib/asan/asan_thread.cpp:104:40
    #3 0x7f1a823e0250 in __nptl_deallocate_tsd (/lib64/libpthread.so.0+0x9250)
    #4 0x7f1a823e0444 in start_thread (/lib64/libpthread.so.0+0x9444)
    #5 0x7f1a822f36d2 in clone (/lib64/libc.so.6+0x1016d2)

Address 0x7f1a756b2df0 is located in stack of thread T1 at offset 208 in frame
    #0 0x7f1a756cebaf in clic_thread_func /data/gannet/ripley/R/packages/tests-clang-SAN/cli/src/thread.c:18

  This frame has 2 object(s):
    [32, 160) 'set' (line 20)
    [192, 196) 'old' (line 27) <== Memory access at offset 208 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T1 created by T0 here:
    #0 0x49736c in pthread_create /data/gannet/ripley/Sources2/LLVM/12.0.0/llvm-project-12.0.0.src/compiler-rt/lib/asan/asan_interceptors.cpp:205:3
    #1 0x7f1a756cefec in clic_start_thread /data/gannet/ripley/R/packages/tests-clang-SAN/cli/src/thread.c:63:13
```

I am not sure what this is. It might be some incompatibility betweeen
ASAN's sigaltstack, and R's signal handling. If I remove our pthread_sigmask()
call, the crash still remains. If I set `ASAN_OPTIONS="use_sigaltstack=0"`
then the issue goes away.