### PR TITLE
Fix environment issue with format_inline

### DIFF
--- a/R/cli.R
+++ b/R/cli.R
@@ -75,16 +75,17 @@ fmt <- function(expr, collapse = FALSE, strip_newline = FALSE, app = NULL) {
 #' it to the screen. It uses [cli_text()] internally.
 #'
 #' @param ... Passed to [cli_text()].
+#' @param .envir Environment to evaluate the expressions in.
 #' @return Character scalar, the formatted string.
 #'
 #' @export
 #' @examples
 #' format_inline("This is a message for {.emph later}.")
 
-format_inline <- function(...) {
+format_inline <- function(..., .envir = parent.frame()) {
   opts <- options(cli.width = Inf)
   on.exit(options(opts), add = TRUE)
-  fmt(cli_text(...))
+  fmt(cli_text(..., .envir = .envir))
 }
 
 #' CLI text


### PR DESCRIPTION
The following code fails for me with cli 3.0.0:

```r
f = function(x = 1) {
  cli::format_inline("{x}")
}

f()

## Error in eval(expr, envir = list(`?` = function(...) stop()), enclos = envir) : object 'x' not found 
```

it seems like `format_inline` should be passing the `parent.frame()` as `.envir` to `cli_text()`. Small fix to add this parameter and pass it appropriately.
