### PR TITLE
Add true color support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cli (development version)
 
+* True color support: `num_ansi_colors()` now detects terminals with
+  24 bit color support, and `make_ansi_style()` uses the exact RGB colors
+  on these terminals.
+
 * The new `col_br_*()` and `bg_br_()` functions create bright versions of
   eight base ANSI colors.
 

--- a/R/ansi.R
+++ b/R/ansi.R
@@ -1,4 +1,6 @@
 
+TRUE_COLORS <- as.integer(256^3)
+
 ansi_builtin_styles <- list(
   reset = list(0, c(0, 22, 23, 24, 27, 28, 29, 39, 49)),
   bold = list(1, 22), # 21 isn't widely supported and 22 does the same thing
@@ -261,7 +263,8 @@ ansi_style_8_from_rgb <- function(rgb, bg) {
 
 ansi_style_from_rgb <- function(rgb, bg, num_colors, grey) {
   if (num_colors < 256) { return(ansi_style_8_from_rgb(rgb, bg)) }
-  ansi256(rgb, bg, grey)
+  if (num_colors < TRUE_COLORS || grey) return(ansi256(rgb, bg, grey))
+  return(ansitrue(rgb, bg))
 }
 
 # nocov start
@@ -324,6 +327,20 @@ ansi256_rgb_index <- function(red, green, blue) {
     232 + round((red + green + blue) / 33) + 1
   } else {
     16 + sum(floor(6 * c(red, green, blue) / 256) * c(36, 6, 1)) + 1
+  }
+}
+
+ansitrue <- function(rgb, bg = FALSE) {
+  if (bg) {
+    list(
+      open = paste0("\x1b[48;2;", rgb[1], ";", rgb[2], ";", rgb[3], "m"),
+      close = "\x1b[49m"
+    )
+  } else {
+    list(
+      open = paste0("\x1b[38;2;", rgb[1], ";", rgb[2], ";", rgb[3], "m"),
+      close = "\x1b[39m"
+    )
   }
 }
 

--- a/R/num-ansi-colors.R
+++ b/R/num-ansi-colors.R
@@ -9,59 +9,6 @@
 #' `num_ansi_colors()` detects if the current R session supports ANSI
 #' sequences, and if it does how many colors are supported.
 #'
-#' @details
-#' The detection mechanism is quite involved and it is designed to work
-#' out of the box on most systems. If it does not work on your system,
-#' please report a bug. Setting options and environment variables to turn
-#' on ANSI support is error prone, because they are inherited in other
-#' environments, e.g. knitr, that might not have ANSI support.
-#'
-#' If you want to _turn off_ ANSI colors, set the `NO_COLOR` environment
-#' variable to a non-empty value.
-#'
-#' The exact detection mechanism is as follows:
-#' 1. If the `cli.num_colors` options is set, that is returned.
-#' 1. If the `R_CLI_NUM_COLORS` env var is set to a non-empty value,
-#'    then it is used.
-#' 1. If the `crayon.enabled` option is set to `FALSE`, 1L is returned.
-#'    (This is for compatibility with code that uses the crayon package.)
-#' 1. If the `crayon.enabled` option is set to `TRUE` and the
-#'    `crayon.colors` option is not set, then 8L is returned.
-#' 1. If the `crayon.enabled` option is set to `TRUE` and the
-#'    `crayon.colors` option is also set, then the latter is returned.
-#'    (This is for compatibility with code that uses the crayon package.)
-#' 1. If the `NO_COLOR` environment variable is set, then 1L is returned.
-#' 1. If we are in knitr, then 1L is returned, to turn off colors in
-#'    `.Rmd` chunks.
-#' 1. If `stream` is `stderr()` and there is an active sink for it, then
-#'    1L is returned.
-#' 1. If R is running inside RGui on Windows, or R.app on macOS, then we
-#'    return 1L.
-#' 1. If R is running inside RStudio, with color support, then the
-#'    appropriate number of colors is returned, usually 256L.
-#' 1. If R is running on Windows, inside an Emacs version that is recent
-#'    enough to support ANSI colors, then 8L is returned. (On Windows,
-#'    Emacs has `isatty(stdout()) == FALSE`, so we need to check for this
-#'    here before dealing with terminals.)
-#' 1. If `stream` is not a terminal, then 1L is returned.
-#' 1. If R is running on Unix, inside an Emacs version that is recent
-#'    enough to support ANSI colors, then 8L is returned.
-#' 1. If `stream` is not the standard output or error, then 1L is returned.
-#' 1. If we are on Windows, under ComEmu or cmder, or ANSICON is loaded,
-#'    then 8L is returned.
-#' 1. Otherwise if we are on Windows, return 1L.
-#' 1. Otherwise we are on Unix and try to run `tput colors` to determine
-#'    the number of colors. If this succeeds, we return its return value,
-#'    except if the `TERM` environment variable is `xterm` and `tput`
-#'    returned 8L, we return 256L, because xterm compatible terminals
-#'    tend to support 256 colors.
-#' 1. If `tput colors` fails, we try to guess. If `COLORTERM` is set
-#'    to any value, we return 8L.
-#' 1. If `TERM` is set to `dumb`, we return 1L.
-#' 1. If `TERM` starts with `screen`, `xterm`, or `vt100`, we return 8L.
-#' 1. If `TERM` contains `color`, `ansi`, `cygwin` or `linux`, we return 8L.
-#' 1. Otherwise we return 1L.
-#'
 #' @param stream The stream that will be used for output, an R connection
 #' object. It can also be a string, one of `"auto"`, `"message"`,
 #' `"stdout"`, `"stderr"`. `"auto"` will select `stdout()` if the session is
@@ -73,6 +20,18 @@
 #' @export
 #' @examples
 #' num_ansi_colors()
+#'
+#' @details
+#' The detection mechanism is quite involved and it is designed to work
+#' out of the box on most systems. If it does not work on your system,
+#' please report a bug. Setting options and environment variables to turn
+#' on ANSI support is error prone, because they are inherited in other
+#' environments, e.g. knitr, that might not have ANSI support.
+#'
+#' If you want to _turn off_ ANSI colors, set the `NO_COLOR` environment
+#' variable to a non-empty value.
+#'
+#' The exact detection mechanism is as follows:
 
 num_ansi_colors <- function(stream = "auto") {
   stream <- get_real_output(stream)
@@ -87,16 +46,26 @@ num_ansi_colors <- function(stream = "auto") {
     std <- "stderr"
   }
 
-  # colors forced?
+  #' 1. If the `cli.num_colors` options is set, that is returned.
+
   opt <- getOption("cli.num_colors", NULL)
   if (!is.null(opt)) return(as.integer(opt))
 
-  # forced via env var
+  #' 1. If the `R_CLI_NUM_COLORS` env var is set to a non-empty value,
+  #'    then it is used.
+
   if ((env <- Sys.getenv("R_CLI_NUM_COLORS", "")) != "") {
     return(as.integer(env))
   }
 
-  # compatiblity with crayon
+  #' 1. If the `crayon.enabled` option is set to `FALSE`, 1L is returned.
+  #'    (This is for compatibility with code that uses the crayon package.)
+  #' 1. If the `crayon.enabled` option is set to `TRUE` and the
+  #'    `crayon.colors` option is not set, then 8L is returned.
+  #' 1. If the `crayon.enabled` option is set to `TRUE` and the
+  #'    `crayon.colors` option is also set, then the latter is returned.
+  #'    (This is for compatibility with code that uses the crayon package.)
+
   cray_opt_has <- getOption("crayon.enabled", NULL)
   cray_opt_num <- getOption("crayon.colors", NULL)
   if (!is.null(cray_opt_has) && !isTRUE(cray_opt_has)) return(1L)
@@ -107,11 +76,17 @@ num_ansi_colors <- function(stream = "auto") {
     return(8L)
   }
 
-  # NO_COLOR env var
+  #' 1. If the `NO_COLOR` environment variable is set, then 1L is returned.
+
   if (!is.na(Sys.getenv("NO_COLOR", NA_character_))) return(1L)
 
-  # knitr?
+  #' 1. If we are in knitr, then 1L is returned, to turn off colors in
+  #'    `.Rmd` chunks.
+
   if (isTRUE(getOption("knitr.in.progress"))) return(1L)
+
+  #' 1. If `stream` is `stderr()` and there is an active sink for it, then
+  #'    1L is returned.
 
   # If a sink is active for "output", then R changes the `stdout()`
   # stream, so we don't need to do anything here.
@@ -119,10 +94,15 @@ num_ansi_colors <- function(stream = "auto") {
   # the `stderr()` stream, so we need to catch this case.
   if (is_stderr && sink.number("message") != 2) return(1L)
 
-  # Rapp?
+  #' 1. If R is running inside RGui on Windows, or R.app on macOS, then we
+  #'    return 1L.
+
+  # RStudio sets GUI to RGui initially, so we'll handle that after RStudio.
   if (.Platform$GUI == "AQUA") return(1L)
 
-  # RStudio?
+  #' 1. If R is running inside RStudio, with color support, then the
+  #'    appropriate number of colors is returned, usually 256L.
+
   rstudio <- rstudio$detect()
   rstudio_colors <- c(
     "rstudio_console",
@@ -138,6 +118,11 @@ num_ansi_colors <- function(stream = "auto") {
   # "Rgui" in RStudio when we are starting up
   if (.Platform$GUI == "Rgui") return(1L)
 
+  #' 1. If R is running on Windows, inside an Emacs version that is recent
+  #'    enough to support ANSI colors, then 8L is returned. (On Windows,
+  #'    Emacs has `isatty(stdout()) == FALSE`, so we need to check for this
+  #'    here before dealing with terminals.)
+
   # Windows Emacs? The top R process will have `--ess` in ESS, but the
   # subprocesses won't. (Without ESS subprocesses will also report 8L
   # colors, this is a problem, but we expect most people use ESS in Emacs.)
@@ -147,11 +132,14 @@ num_ansi_colors <- function(stream = "auto") {
     return(8L)
   }
 
-  # For the rest, we are either in a terminal, or there is no ANSI support.
-  if (!isatty(stream)) return(1L)
+  #' 1. If `stream` is not stdout or stderr in a terminal, then 1L is
+  #'    returned.
 
-  # If `stream` is not stdout or stderr then we give up here
+  if (!isatty(stream)) return(1L)
   if (!is_std) return(1L)
+
+  #' 1. Otherwise we use and cache the result of the terminal color
+  #'     detection (see below).
 
   # Otherwise use/set the cache
   if (is.null(clienv$num_colors)) clienv$num_colors <- list()
@@ -159,40 +147,72 @@ num_ansi_colors <- function(stream = "auto") {
   clienv$num_colors[[std]]
 }
 
+#' @rdname num_ansi_colors
+#' @details
+#' The terminal color detection algorithm:
+
 detect_tty_colors <- function() {
-  # Emacs on Unix?
+
+  #' 1. If the `COLORTERM` env var is set to `truecolor` or `24bit`,
+  #'    then we return 16 miliion colors.
+  #' 1. If the `COLORTERM` env var is set to anything else, then we
+  #'    return 8L.
+
+  ct <- Sys.getenv("COLORTERM", NA_character_)
+  if (!is.na(ct)) {
+    if (ct == "truecolor" || ct == "24bit") {
+      return(TRUE_COLORS)
+    } else {
+      return(8L)
+    }
+  }
+
+  #' 1. If R is running on Unix, inside an Emacs version that is recent
+  #'    enough to support ANSI colors, then 8L is returned.
+
   if (os_type() == "unix" && is_emacs_with_color()) return(8L)
 
-  # RStudio terminal and Windows, apparently only eight colors
-  win10_build_ok <- win10_build() >= 16257
-  if (os_type() == "windows" && win10_build_ok &&
+  #' 1. If we are on Windows in an RStudio terminal, then apparently
+  #'    we only have eight colors.
+
+  win10 <- win10_build()
+  if (os_type() == "windows" && win10_build >= 10586 &&
       rstudio$detect()$type == "rstudio_terminal") {
     # this is rather weird, but echo turns on color support :D
     system2("cmd", c("/c", "echo 1 >NUL"))
     return(8L)
   }
 
-  # Windows terminal with native color support?
-  if (os_type() == "windows" && win10_build_ok) {
+  #' 1. If we are in a recent enough Windows 10 terminal, then there
+  #'    is either true color (from build 14931) or 256 color (from
+  #'    build 10586) support.
+
+  if (os_type() == "windows" && win10 >= 10586) {
     # this is rather weird, but echo turns on color support :D
     system2("cmd", c("/c", "echo 1 >NUL"))
-    return(256L)
+    # https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/
+    if (win10 >= 14931) return(TRUE_COLORS) else return(256L)
   }
 
-  # Windows terminal with 3rd party color support?
   if (os_type() == "windows") {
+
+    #' 1. If we are on Windows, under ComEmu or cmder, or ANSICON is loaded,
+    #'    then 8L is returned.
+
     if (Sys.getenv("ConEmuANSI") == "ON" ||
         Sys.getenv("CMDER_ROOT") != "") {
       return(8L)
     }
     if (Sys.getenv("ANSICON") != "") return(8L)
 
-    ## Are we in another windows terminal or GUI? :(
+    #' 1. Otherwise if we are on Windows, return 1L.
+
     return(1L)
   }
 
-  # Otherwise Unix terminal. Try to run tput colors. If it did not run, but
-  # the terminal should still have colors, then we report 8.
+  #' 1. Otherwise we are on Unix and try to run `tput colors` to determine
+  #'    the number of colors. If this succeeds, we return its return value.
+
   cols <- suppressWarnings(try(
     silent = TRUE,
     as.numeric(system("tput colors 2>/dev/null", intern = TRUE))[1]
@@ -202,18 +222,22 @@ detect_tty_colors <- function() {
   }
   if (cols %in% c(-1, 0, 1)) { return(1) }
 
-  # If tput returns 8, but TERM is xterm, we return 256, as most xterm
-  # compatible terminals in fact do support 256 colors.
-  # There is some discussion about this here:
-  # \url{https://github.com/r-lib/crayon/issues/17}
+  #'    If the `TERM` environment variable is `xterm` and `tput`
+  #'    returned 8L, we return 256L, because xterm compatible terminals
+  #'    tend to support 256 colors
+  #'    (https://github.com/r-lib/crayon/issues/17)
+
   if (cols == 8 && identical(Sys.getenv("TERM"), "xterm")) cols <- 256
+
+  #' 1. If `TERM` is set to `dumb`, we return 1L.
+  #' 1. If `TERM` starts with `screen`, `xterm`, or `vt100`, we return 8L.
+  #' 1. If `TERM` contains `color`, `ansi`, `cygwin` or `linux`, we return 8L.
+  #' 1. Otherwise we return 1L.
 
   cols
 }
 
 guess_tty_colors <- function() {
-  if ("COLORTERM" %in% names(Sys.getenv())) return(8L)
-
   term <- Sys.getenv("TERM")
   if (term == "dumb") return (1L)
 

--- a/man/num_ansi_colors.Rd
+++ b/man/num_ansi_colors.Rd
@@ -2,9 +2,12 @@
 % Please edit documentation in R/num-ansi-colors.R
 \name{num_ansi_colors}
 \alias{num_ansi_colors}
+\alias{detect_tty_colors}
 \title{Detect the number of ANSI colors to use}
 \usage{
 num_ansi_colors(stream = "auto")
+
+detect_tty_colors()
 }
 \arguments{
 \item{stream}{The stream that will be used for output, an R connection
@@ -59,20 +62,34 @@ appropriate number of colors is returned, usually 256L.
 enough to support ANSI colors, then 8L is returned. (On Windows,
 Emacs has \code{isatty(stdout()) == FALSE}, so we need to check for this
 here before dealing with terminals.)
-\item If \code{stream} is not a terminal, then 1L is returned.
+\item If \code{stream} is not stdout or stderr in a terminal, then 1L is
+returned.
+\item Otherwise we use and cache the result of the terminal color
+detection (see below).
+}
+
+The terminal color detection algorithm:
+\enumerate{
+\item If the \code{COLORTERM} env var is set to \code{truecolor} or \verb{24bit},
+then we return 16 miliion colors.
+\item If the \code{COLORTERM} env var is set to anything else, then we
+return 8L.
 \item If R is running on Unix, inside an Emacs version that is recent
 enough to support ANSI colors, then 8L is returned.
-\item If \code{stream} is not the standard output or error, then 1L is returned.
+\item If we are on Windows in an RStudio terminal, then apparently
+we only have eight colors.
+\item If we are in a recent enough Windows 10 terminal, then there
+is either true color (from build 14931) or 256 color (from
+build 10586) support.
 \item If we are on Windows, under ComEmu or cmder, or ANSICON is loaded,
 then 8L is returned.
 \item Otherwise if we are on Windows, return 1L.
 \item Otherwise we are on Unix and try to run \verb{tput colors} to determine
-the number of colors. If this succeeds, we return its return value,
-except if the \code{TERM} environment variable is \code{xterm} and \code{tput}
+the number of colors. If this succeeds, we return its return value.
+If the \code{TERM} environment variable is \code{xterm} and \code{tput}
 returned 8L, we return 256L, because xterm compatible terminals
-tend to support 256 colors.
-\item If \verb{tput colors} fails, we try to guess. If \code{COLORTERM} is set
-to any value, we return 8L.
+tend to support 256 colors
+(https://github.com/r-lib/crayon/issues/17)
 \item If \code{TERM} is set to \code{dumb}, we return 1L.
 \item If \code{TERM} starts with \code{screen}, \code{xterm}, or \code{vt100}, we return 8L.
 \item If \code{TERM} contains \code{color}, \code{ansi}, \code{cygwin} or \code{linux}, we return 8L.
@@ -81,6 +98,7 @@ to any value, we return 8L.
 }
 \examples{
 num_ansi_colors()
+
 }
 \seealso{
 Other ANSI styling: 


### PR DESCRIPTION
* `num_ansi_colors()` now detects terminals that
  support 24 bit ANSI colors.
* `make_ansi_style()` now creates 24 bit colors for
  `#rrggbb` color specifications and color names,
  on terminals that support 24 bit colors.

Closes #208.