### PR TITLE
Add cli_bullets field to rlang conditions

### DIFF
--- a/R/bullets.R
+++ b/R/bullets.R
@@ -79,8 +79,7 @@ cli_bullets <- function(text, id = NULL, class = NULL,
 #' @export
 
 cli_bullets_raw <- function(text, id = NULL, class = NULL) {
-  text <- gsub("{", "{{", text, fixed = TRUE)
-  text <- gsub("}", "}}", text, fixed = TRUE)
+  text <- cli_escape(text)
   cli__message(
     "memo",
     list(

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -34,20 +34,38 @@
 #' @export
 
 cli_abort <- function(message, ..., .envir = parent.frame()) {
-  rlang::abort(format_error(message, .envir = .envir), ...)
+  message[] <- vcapply(message, format_inline, .envir = .envir)
+  escaped_message <- cli_escape(message)
+  rlang::abort(
+    format_error(escaped_message, .envir = .envir),
+    cli_bullets = message,
+    ...
+  )
 }
 
 #' @rdname cli_abort
 #' @export
 
 cli_warn <- function(message, ..., .envir = parent.frame()) {
-  rlang::warn(format_warning(message, .envir = .envir), ...)
+  message[] <- vcapply(message, format_inline, .envir = .envir)
+  escaped_message <- cli_escape(message)
+  rlang::warn(
+    format_warning(escaped_message, .envir = .envir),
+    cli_bullets = message,
+    ...
+  )
 }
 
 #' @rdname cli_abort
 #' @export
 
 cli_inform <- function(message, ..., .envir = parent.frame()) {
+  message[] <- vcapply(message, format_inline, .envir = .envir)
+  escaped_message <- cli_escape(message)
   cli_status("", "", "")
-  rlang::inform(format_message(message, .envir = .envir), ...)
+  rlang::inform(
+    format_message(message, .envir = .envir),
+    cli_bullets = message,
+    ...
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,9 @@ format_iso_8601 <- function(p) {
 has_packages <- function(pkgs) {
   all(vapply(pkgs, requireNamespace, logical(1), quietly = TRUE))
 }
+
+cli_escape <- function(x) {
+  x <- gsub("{", "{{", x, fixed = TRUE)
+  x <- gsub("}", "}}", x, fixed = TRUE)
+  x
+}

--- a/tests/testthat/_snaps/rlang-errors.md
+++ b/tests/testthat/_snaps/rlang-errors.md
@@ -23,6 +23,14 @@
       i There are 26 elements.
       x You've tried to subset element 100.
 
+---
+
+    Code
+      err$cli_bullets
+    Output
+                                                                                    x 
+               "`n` must be a numeric vector" "You've supplied a <character> vector." 
+
 # cli_abort [ansi]
 
     Code
@@ -47,6 +55,16 @@
       [1m[22m[1mMust index an existing element:[22m
       [36mi[39m There are 26 elements.
       [31mx[39m You've tried to subset element 100.
+
+---
+
+    Code
+      err$cli_bullets
+    Output
+                                                                     
+      "\033[30m\033[47m`n`\033[49m\033[39m must be a numeric vector" 
+                                                                   x 
+             "You've supplied a \033[34m<character>\033[39m vector." 
 
 # cli_abort [unicode]
 
@@ -73,6 +91,14 @@
       ℹ There are 26 elements.
       ✖ You've tried to subset element 100.
 
+---
+
+    Code
+      err$cli_bullets
+    Output
+                                                                                    x 
+               "`n` must be a numeric vector" "You've supplied a <character> vector." 
+
 # cli_abort [fancy]
 
     Code
@@ -98,6 +124,16 @@
       [36mℹ[39m There are 26 elements.
       [31m✖[39m You've tried to subset element 100.
 
+---
+
+    Code
+      err$cli_bullets
+    Output
+                                                                     
+      "\033[30m\033[47m`n`\033[49m\033[39m must be a numeric vector" 
+                                                                   x 
+             "You've supplied a \033[34m<character>\033[39m vector." 
+
 # cli_warn [plain]
 
     Code
@@ -120,6 +156,16 @@
       Must index an existing element:
       i There are 26 elements.
       x You've tried to subset element 100.
+
+---
+
+    Code
+      wrn$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
 
 # cli_warn [ansi]
 
@@ -144,6 +190,16 @@
       [36mi[39m There are 26 elements.
       [31mx[39m You've tried to subset element 100.
 
+---
+
+    Code
+      wrn$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
+
 # cli_warn [unicode]
 
     Code
@@ -167,6 +223,16 @@
       ℹ There are 26 elements.
       ✖ You've tried to subset element 100.
 
+---
+
+    Code
+      wrn$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
+
 # cli_warn [fancy]
 
     Code
@@ -189,6 +255,16 @@
       [1m[22m[1mMust index an existing element:[22m
       [36mℹ[39m There are 26 elements.
       [31m✖[39m You've tried to subset element 100.
+
+---
+
+    Code
+      wrn$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
 
 # cli_inform [plain]
 
@@ -217,6 +293,16 @@
       i There are 26 elements.
       x You've tried to subset element 100.
 
+---
+
+    Code
+      tail(inf, 1)[[1]]$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
+
 # cli_inform [ansi]
 
     Code
@@ -243,6 +329,16 @@
       [1m[22mMust index an existing element:
       [36mi[39m There are 26 elements.
       [31mx[39m You've tried to subset element 100.
+
+---
+
+    Code
+      tail(inf, 1)[[1]]$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
 
 # cli_inform [unicode]
 
@@ -271,6 +367,16 @@
       ℹ There are 26 elements.
       ✖ You've tried to subset element 100.
 
+---
+
+    Code
+      tail(inf, 1)[[1]]$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
+
 # cli_inform [fancy]
 
     Code
@@ -297,6 +403,16 @@
       [1m[22mMust index an existing element:
       [36mℹ[39m There are 26 elements.
       [31m✖[39m You've tried to subset element 100.
+
+---
+
+    Code
+      tail(inf, 1)[[1]]$cli_bullets
+    Output
+                                                                                i 
+          "Must index an existing element:"              "There are 26 elements." 
+                                          x 
+      "You've tried to subset element 100." 
 
 # cli_abort width in RStudio
 

--- a/tests/testthat/test-rlang-errors.R
+++ b/tests/testthat/test-rlang-errors.R
@@ -18,6 +18,16 @@ test_that_cli("cli_abort", {
       "x" = "You've tried to subset element {idx}."
     ))
   }))
+
+  n <- "boo"
+  err <- tryCatch(
+    cli_abort(c(
+      "{.var n} must be a numeric vector",
+      "x" = "You've supplied a {.cls {class(n)}} vector."
+    )),
+    error = function(e) e
+  )
+  expect_snapshot(err$cli_bullets)
 })
 
 test_that_cli("cli_warn", {
@@ -39,6 +49,18 @@ test_that_cli("cli_warn", {
       "x" = "You've tried to subset element {idx}."
     ))
   }))
+
+  len <- 26
+  idx <- 100
+  wrn <- tryCatch(
+    cli_warn(c(
+            "Must index an existing element:",
+      "i" = "There {?is/are} {len} element{?s}.",
+      "x" = "You've tried to subset element {idx}."
+    )),
+    warning = function(w) w
+  )
+  expect_snapshot(wrn$cli_bullets)
 })
 
 test_that_cli("cli_inform", {
@@ -60,6 +82,23 @@ test_that_cli("cli_inform", {
       "x" = "You've tried to subset element {idx}."
     ))
   }))
+
+  len <- 26
+  idx <- 100
+  # This is weirder because cli_inform emits another cli message first
+  inf <- NULL
+  withCallingHandlers(
+    cli_inform(c(
+            "Must index an existing element:",
+      "i" = "There {?is/are} {len} element{?s}.",
+      "x" = "You've tried to subset element {idx}."
+    )),
+    message = function(m) {
+      inf <<- c(inf, list(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  expect_snapshot(tail(inf, 1)[[1]]$cli_bullets)
 })
 
 test_that("cli_abort width in RStudio", {


### PR DESCRIPTION
Containing inline-formatted bullets, for future wrapping.

```r
❯ cli_abort(c("{.emph Not} good", "!" = "Not good at all: {2} failure{?s}", "i" = lorem_ipsum(1,1)))
Error: Not good
! Not good at all: 2 failures
ℹ Fugiat ut ut cillum sint culpa.
Run `rlang::last_error()` to see where the error occurred.

❯ rlang::last_error()$cli_bullets
                                                                  !
        "\033[3mNot\033[23m good"     "Not good at all: 2 failures"
                                i
"Fugiat ut ut cillum sint culpa."
```
