### PR TITLE
progress: fix build on GNU/Hurd

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -13,7 +13,7 @@
 
 /* for older macOS versions */
 
-#ifdef __MACH__
+#if defined(__APPLE__) && defined(__MACH__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>


### PR DESCRIPTION
mach.h is not only for MacOS, and mach/clock.h is only on MacOS.
GNU/Hurd happens to have the standard clock_gettime.