### PR TITLE
Do not throw conditions from `format_error()` & co

### DIFF
--- a/R/format-conditions.R
+++ b/R/format-conditions.R
@@ -44,10 +44,13 @@ format_error <- function(message, .envir = parent.frame()) {
     on.exit(options(oldopt), add = TRUE)
   }
 
-  formatted1 <- fmt({
+  # We need to create a frame here, so cli_div() is closed.
+  # Cannot use local(), it does not work in snapshot tests, it potentially
+  # has issues elsewhere as well.
+  formatted1 <- fmt((function() {
     cli_div(class = "cli_rlang cli_abort")
     cli_bullets(message, .envir = .envir)
-  }, collapse = TRUE, strip_newline = TRUE)
+  })(), collapse = TRUE, strip_newline = TRUE)
 
   # remove "Error: " that was only needed for the wrapping
   formatted1[1] <- sub("Error: ", "", formatted1[1])
@@ -64,10 +67,10 @@ format_warning <- function(message, .envir = parent.frame()) {
     names(message)[1] <- "1"
   }
 
-  formatted1 <- fmt({
+  formatted1 <- fmt((function() {
     cli_div(class = "cli_rlang cli_warn")
     cli_bullets(message, .envir = .envir)
-  }, collapse = TRUE, strip_newline = TRUE)
+  })(), collapse = TRUE, strip_newline = TRUE)
 
   update_rstudio_color(formatted1)
 }
@@ -76,10 +79,10 @@ format_warning <- function(message, .envir = parent.frame()) {
 #' @export
 
 format_message <- function(message, .envir = parent.frame()) {
-  formatted1 <- fmt({
+  formatted1 <- fmt((function() {
     cli_div(class = "cli_rlang cli_inform")
     cli_bullets(message, .envir = .envir)
-  }, collapse = TRUE, strip_newline = TRUE)
+  })(), collapse = TRUE, strip_newline = TRUE)
   update_rstudio_color(formatted1)
 }
 

--- a/tests/testthat/test-format-conditions.R
+++ b/tests/testthat/test-format-conditions.R
@@ -122,3 +122,14 @@ test_that("named first element", {
     format_warning(c("*" = "foo", "*" = "bar"))
   )
 })
+
+test_that("no cli conditions are thrown", {
+  cnd <- NULL
+  withCallingHandlers({
+    format_error("error")
+    format_warning("warning")
+    format_message("message")
+  }, cli_message = function(cnd_) cnd <<- cnd_)
+
+  expect_null(cnd)
+})


### PR DESCRIPTION
Make sure the `cli_end()` tag is recorded as well, and
it is not thrown after the recording is done.

Closes #354.