### PR TITLE
Use glue's `.literal` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ BugReports: https://github.com/r-lib/cli/issues
 RoxygenNote: 7.1.2
 Depends: R (>= 2.10)
 Imports:
-    glue,
+    glue (>= 1.5.1.9000),
     utils
 Suggests:
     asciicast,
@@ -41,7 +41,9 @@ Suggests:
     tibble,
     whoami,
     withr
-Remotes: r-lib/testthat@fix/snapshot-empty-lines
+Remotes:  
+    r-lib/testthat@fix/snapshot-empty-lines,
+    tidyverse/glue
 Config/testthat/edition: 3
 Config/Needs/website:
     r-lib/asciicast,

--- a/R/inline.R
+++ b/R/inline.R
@@ -216,6 +216,7 @@ clii__inline <- function(app, text, .list) {
       .transformer = inline_transformer,
       .open = paste0("{", t$values$marker),
       .close = paste0(t$values$marker, "}"),
+      .literal = TRUE,
       .trim = TRUE
     )
   })
@@ -272,7 +273,7 @@ glue_cmd <- function(..., .envir) {
   str <- paste0(unlist(list(...), use.names = FALSE), collapse = "")
   values <- new.env(parent = emptyenv())
   transformer <- make_cmd_transformer(values)
-  pstr <- glue::glue(str, .envir = .envir, .transformer = transformer, .trim = TRUE)
+  pstr <- glue::glue(str, .envir = .envir, .transformer = transformer, .literal = TRUE, .trim = TRUE)
   glue_delay(
     str = post_process_plurals(pstr, values),
     values = values


### PR DESCRIPTION
Fixes #370

This is a rather quick / naive PR, but I just want to demo that the new `.literal` argument of glue allows #370 to be addressed.

These are results with ~dev~ glue and this PR:

*Update: the new `.literal` argument now exists in glue 1.6.0, released on CRAN 2021-12-17.*

``` r
#pak::pkg_install("tidyverse/glue")
library(glue)
devtools::load_all("~/rrr/cli")
#> ℹ Loading cli

packageVersion("glue")
#> [1] '1.5.1.9000'

cli_dl(
  c(
    "test_1" = "all good",
    "test_2" = "not #good (ok now!)",
    "test_3" = "no' good either (ok now!)",
    "test_4" = "no\" good also (ok now!)"
  )
)
#> test_1: all good
#> test_2: not #good (ok now!)
#> test_3: no' good either (ok now!)
#> test_4: no" good also (ok now!)

cli::cli_alert_success("Qapla'")
#> ✓ Qapla'

cli::cli_text("{.url https://example.com/#section}")
#> <https://example.com/#section>
```

<sup>Created on 2021-12-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>