### PR TITLE
incorrect use of %||%

### DIFF
--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -25,7 +25,7 @@
 #' cat("This is an", style_hyperlink("R", "https://r-project.org"), "link.\n")
 
 style_hyperlink <- function(text, url, params = NULL) {
-  params <- params %||% glue::glue_collapse(sep = ":",
+  params <- glue::glue_collapse(sep = ":",
     glue::glue("{names(params)}={params}")
   )
 


### PR DESCRIPTION
Sorry about the noise, the previous pr was not using `%||%` correctly: 

``` r
library(cli)
options(cli.hyperlink = TRUE)

str(style_hyperlink("a", "b", c(target = "viewer")))
#>  'ansi_string' chr "\033]8;target=viewer;b\aa\033]8;;\a"
str(style_hyperlink("a", "b"))
#>  'ansi_string' chr "\033]8;;b\aa\033]8;;\a"
```

<sup>Created on 2022-01-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>