### PR TITLE
Partial fixes for testthat 3.1.2

### DIFF
--- a/tests/testthat/_snaps/containers.md
+++ b/tests/testthat/_snaps/containers.md
@@ -103,11 +103,14 @@
       
       
       
+      
       until here
       
       
       
+      
       no space, still
+      
       
       
       

--- a/tests/testthat/_snaps/progress-client.md
+++ b/tests/testthat/_snaps/progress-client.md
@@ -66,6 +66,6 @@
     Code
       capture_cli_messages(fun())
     Output
-      [1] "\rfirst\r"     "\r     \r"     "just 1 text\n" "first\r"      
-      [5] "\rfirst\r"     "\r     \r"    
+      [1] "\rfirst\r"     "\r      \r"    "just 1 text\n" "first\r"      
+      [5] "\rfirst\r"     "\r      \r"   
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -159,7 +159,7 @@ win2unix <- function (str) {
 
 expect_snapshot <- function(...) {
   if (packageVersion("testthat") >= "3.1.1" &&
-      packageVersion("testthat") <= "3.1.1.9000") {
+      packageVersion("testthat") < "3.1.1.9000") {
     skip("testthat bug with snapshots")
   }
   testthat::expect_snapshot(...)

--- a/tests/testthat/test-ansi.R
+++ b/tests/testthat/test-ansi.R
@@ -1,18 +1,17 @@
 
-op <- options(cli.num_colors = 256L)
-on.exit(options(op))
-
 test_that("Classes", {
   expect_equal(class(style_underline("foo")), c("ansi_string", "character"))
 })
 
 test_that("Coloring and highlighting works", {
+  local_reproducible_output(crayon = TRUE)
   expect_equal(c(style_underline("foo")), "\u001b[4mfoo\u001b[24m")
   expect_equal(c(col_red("foo")), "\u001b[31mfoo\u001b[39m")
   expect_equal(c(bg_red("foo")), "\u001b[41mfoo\u001b[49m")
 })
 
 test_that("Applying multiple styles at once works", {
+  local_reproducible_output(crayon = TRUE)
   st <- combine_ansi_styles(col_red, bg_green, "underline")
   expect_equal(
     c(st("foo")),
@@ -24,6 +23,7 @@ test_that("Applying multiple styles at once works", {
 })
 
 test_that("Nested styles are supported", {
+  local_reproducible_output(crayon = TRUE)
   st <- combine_ansi_styles(style_underline, bg_blue)
   expect_equal(
     c(col_red("foo", st("bar"), "!")),
@@ -31,12 +31,14 @@ test_that("Nested styles are supported", {
 })
 
 test_that("Nested styles of the same type are supported", {
+  local_reproducible_output(crayon = TRUE)
   expect_equal(
     c(col_red("a", col_blue("b", col_green("c"), "b"), "c")),
     "\u001b[31ma\u001b[34mb\u001b[32mc\u001b[34mb\u001b[31mc\u001b[39m")
 })
 
 test_that("Reset all styles", {
+  local_reproducible_output(crayon = TRUE)
   st <- combine_ansi_styles("red", bg_green, "underline")
   ok <- c(
     paste0(
@@ -50,5 +52,6 @@ test_that("Reset all styles", {
 })
 
 test_that("Variable number of arguments", {
+  local_reproducible_output(crayon = TRUE)
   expect_equal(c(col_red("foo", "bar")), "\u001b[31mfoobar\u001b[39m")
 })

--- a/tests/testthat/test-cat-helpers.R
+++ b/tests/testthat/test-cat-helpers.R
@@ -10,7 +10,7 @@ test_that("cat_line", {
   exp <- "This is a line of text."
   expect_equal(readLines(tmp, warn = FALSE), exp)
 
-  local_cli_config(num_colors = 256L)
+  local_reproducible_output(crayon = TRUE)
 
   expect_snapshot({
     cat_line("This is ", "a ", "line of text.", col = "red")

--- a/tests/testthat/test-status-bar.R
+++ b/tests/testthat/test-status-bar.R
@@ -1,4 +1,3 @@
-
 start_app()
 on.exit(stop_app(), add = TRUE)
 


### PR DESCRIPTION
Failures I don't know how to fix:

* `test-themes.R` — I can't see what's changed in the diffs and I don't know why testthat 3.1.2 would affect this. I tried moving the local options into the test, but that didn't help either
* `test-status-bar.R` — we're consistently off by a space, but I don't know why this would have changed.