### PR TITLE
Add support for ansi fast blink

### DIFF
--- a/src/ansi.c
+++ b/src/ansi.c
@@ -217,6 +217,9 @@ static void clic__ansi_update_state(const char *param,
     } else if (num == 5) {
       state->new.blink = 1;
 
+    } else if (num == 6) {
+      state->new.blink = 1;
+
     } else if (num == 7) {
       state->new.inverse = 1;
 


### PR DESCRIPTION
Hi there

I just noted that you support some not widely used ansi codes. (which is good)
But this one was missing :)
The fast blink works for example in GNOME terminal.

I am not sure if I must create any tests.

ref: https://en.wikipedia.org/wiki/ANSI_escape_code