### PR TITLE
rlang 1.0.0 snapshots

### DIFF
--- a/tests/testthat/_snaps/rlang-errors.md
+++ b/tests/testthat/_snaps/rlang-errors.md
@@ -139,7 +139,7 @@
     Code
       n <- "boo"
       cli_warn(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
-    Warning <warning>
+    Warning <rlang_warning>
       `n` must be a numeric vector
       x You've supplied a <character> vector.
 
@@ -152,7 +152,7 @@
         cli_warn(c("Must index an existing element:", i = "There {?is/are} {len} element{?s}.",
           x = "You've tried to subset element {idx}."))
       })
-    Warning <warning>
+    Warning <rlang_warning>
       Must index an existing element:
       i There are 26 elements.
       x You've tried to subset element 100.
@@ -172,7 +172,7 @@
     Code
       n <- "boo"
       cli_warn(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22m[30m[47m`n`[49m[39m must be a numeric vector
       [31mx[39m You've supplied a [34m<character>[39m vector.
 
@@ -185,7 +185,7 @@
         cli_warn(c("Must index an existing element:", i = "There {?is/are} {len} element{?s}.",
           x = "You've tried to subset element {idx}."))
       })
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22mMust index an existing element:
       [36mi[39m There are 26 elements.
       [31mx[39m You've tried to subset element 100.
@@ -205,7 +205,7 @@
     Code
       n <- "boo"
       cli_warn(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
-    Warning <warning>
+    Warning <rlang_warning>
       `n` must be a numeric vector
       ✖ You've supplied a <character> vector.
 
@@ -218,7 +218,7 @@
         cli_warn(c("Must index an existing element:", i = "There {?is/are} {len} element{?s}.",
           x = "You've tried to subset element {idx}."))
       })
-    Warning <warning>
+    Warning <rlang_warning>
       Must index an existing element:
       ℹ There are 26 elements.
       ✖ You've tried to subset element 100.
@@ -238,7 +238,7 @@
     Code
       n <- "boo"
       cli_warn(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22m[30m[47m`n`[49m[39m must be a numeric vector
       [31m✖[39m You've supplied a [34m<character>[39m vector.
 
@@ -251,7 +251,7 @@
         cli_warn(c("Must index an existing element:", i = "There {?is/are} {len} element{?s}.",
           x = "You've tried to subset element {idx}."))
       })
-    Warning <warning>
+    Warning <rlang_warning>
       [1m[22mMust index an existing element:
       [36mℹ[39m There are 26 elements.
       [31m✖[39m You've tried to subset element 100.
@@ -273,7 +273,7 @@
       cli_inform(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       `n` must be a numeric vector
       x You've supplied a <character> vector.
 
@@ -288,7 +288,7 @@
       })
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       Must index an existing element:
       i There are 26 elements.
       x You've tried to subset element 100.
@@ -310,7 +310,7 @@
       cli_inform(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       [1m[22m[30m[47m`n`[49m[39m must be a numeric vector
       [31mx[39m You've supplied a [34m<character>[39m vector.
 
@@ -325,7 +325,7 @@
       })
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       [1m[22mMust index an existing element:
       [36mi[39m There are 26 elements.
       [31mx[39m You've tried to subset element 100.
@@ -347,7 +347,7 @@
       cli_inform(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       `n` must be a numeric vector
       ✖ You've supplied a <character> vector.
 
@@ -362,7 +362,7 @@
       })
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       Must index an existing element:
       ℹ There are 26 elements.
       ✖ You've tried to subset element 100.
@@ -384,7 +384,7 @@
       cli_inform(c("{.var n} must be a numeric vector", x = "You've supplied a {.cls {class(n)}} vector."))
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       [1m[22m[30m[47m`n`[49m[39m must be a numeric vector
       [31m✖[39m You've supplied a [34m<character>[39m vector.
 
@@ -399,7 +399,7 @@
       })
     Message <cliMessage>
       
-    Message <message>
+    Message <rlang_message>
       [1m[22mMust index an existing element:
       [36mℹ[39m There are 26 elements.
       [31m✖[39m You've tried to subset element 100.

--- a/tests/testthat/test-rlang-errors.R
+++ b/tests/testthat/test-rlang-errors.R
@@ -31,6 +31,8 @@ test_that_cli("cli_abort", {
 })
 
 test_that_cli("cli_warn", {
+  skip_if_not_installed("rlang", "1.0.0")
+
   withr::local_options(cli_theme_dark = FALSE)
   expect_snapshot({
     n <- "boo"
@@ -64,6 +66,8 @@ test_that_cli("cli_warn", {
 })
 
 test_that_cli("cli_inform", {
+  skip_if_not_installed("rlang", "1.0.0")
+
   withr::local_options(cli.ansi = FALSE)
   expect_snapshot({
     n <- "boo"


### PR DESCRIPTION
I don't understand test failures in the progress bar where one extra space seems to be emitted.