### PR TITLE
Update `cli_abort()` for rlang 1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,15 @@
 
 ## Other changes
 
+* `cli_abort()` has been updated to work nicely with rlang 1.0. The
+  default `call` and backtrace soft-truncation are set to `.envir`
+  (which itself is set to the immediate caller of `cli_abort()` by
+  default).
+
+  Line formatting now happens lazily at display time via
+  `rlang::cnd_message()` (which is called by the `conditionMessage()`
+  method for rlang errors).
+
 * New `hash_sha256()` function to calculate SHA-256 hashes. New
   `hash_raw_*()`, `hash_obj_*()` and `hash_file_*()` functions to calculate
   various hashes of raw vectors, R objects and files.

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -30,16 +30,20 @@
 #' @param ... Passed to [rlang::abort()], [rlang::warn()] or
 #'   [rlang::inform()].
 #' @param .envir Environment to evaluate the glue expressions in.
+#' @inheritParams rlang::abort
 #'
 #' @export
 
-cli_abort <- function(message, ..., .envir = parent.frame()) {
+cli_abort <- function(message,
+                      ...,
+                      .envir = parent.frame(),
+                      call = .envir) {
   message[] <- vcapply(message, format_inline, .envir = .envir)
-  escaped_message <- cli_escape(message)
   rlang::abort(
-    format_error(escaped_message, .envir = .envir),
-    cli_bullets = message,
-    ...
+    message,
+    ...,
+    call = call,
+    use_cli_format = TRUE
   )
 }
 

--- a/man/cli_abort.Rd
+++ b/man/cli_abort.Rd
@@ -7,7 +7,7 @@
 \title{Signal an error, warning or message with a cli formatted
 message}
 \usage{
-cli_abort(message, ..., .envir = parent.frame())
+cli_abort(message, ..., .envir = parent.frame(), call = .envir)
 
 cli_warn(message, ..., .envir = parent.frame())
 
@@ -20,6 +20,18 @@ cli_inform(message, ..., .envir = parent.frame())
 \code{\link[rlang:abort]{rlang::inform()}}.}
 
 \item{.envir}{Environment to evaluate the glue expressions in.}
+
+\item{call}{The execution environment of a currently running
+function, e.g. \code{call = caller_env()}. The corresponding function
+call is retrieved and mentioned in error messages as the source
+of the error.
+
+You only need to supply \code{call} when throwing a condition from a
+helper function which wouldn't be relevant to mention in the
+message.
+
+Can also be \code{NULL} or a \link[rlang:topic-defuse]{defused function call} to
+respectively not display any call or hard-code a code to display.}
 }
 \description{
 These functions let you create error, warning or diagnostic
@@ -27,14 +39,12 @@ messages with cli formatting, including inline styling,
 pluralization and glue substitutions.
 }
 \details{
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{n <- "boo"
+\if{html}{\out{<div class="sourceCode {asciicast cli-abort}">}}\preformatted{n <- "boo"
 cli_abort(c(
         "\{.var n\} must be a numeric vector",
   "x" = "You've supplied a \{.cls \{class(n)\}\} vector."
 ))
-}\if{html}{\out{</div>}}
-
-\if{html}{\figure{cli-abort.svg}}\if{html}{\out{<div class="sourceCode r">}}\preformatted{len <- 26
+}\if{html}{\out{</div>}}\if{html}{\out{<div class="sourceCode {asciicast cli-abort-2}">}}\preformatted{len <- 26
 idx <- 100
 cli_abort(c(
         "Must index an existing element:",
@@ -42,6 +52,4 @@ cli_abort(c(
   "x" = "You've tried to subset element \{idx\}."
 ))
 }\if{html}{\out{</div>}}
-
-\if{html}{\figure{cli-abort-2.svg}}
 }

--- a/tests/testthat/_snaps/rlang-errors.md
+++ b/tests/testthat/_snaps/rlang-errors.md
@@ -26,7 +26,7 @@
 ---
 
     Code
-      err$cli_bullets
+      c(err$message, err$body)
     Output
                                                                                     x 
                "`n` must be a numeric vector" "You've supplied a <character> vector." 
@@ -59,7 +59,7 @@
 ---
 
     Code
-      err$cli_bullets
+      c(err$message, err$body)
     Output
                                                                      
       "\033[30m\033[47m`n`\033[49m\033[39m must be a numeric vector" 
@@ -94,7 +94,7 @@
 ---
 
     Code
-      err$cli_bullets
+      c(err$message, err$body)
     Output
                                                                                     x 
                "`n` must be a numeric vector" "You've supplied a <character> vector." 
@@ -127,7 +127,7 @@
 ---
 
     Code
-      err$cli_bullets
+      c(err$message, err$body)
     Output
                                                                      
       "\033[30m\033[47m`n`\033[49m\033[39m must be a numeric vector" 
@@ -447,4 +447,32 @@
       cat(update_rstudio_color("color me interested"))
     Output
       [32mcolor me interested[39m
+
+# cli_abort() captures correct call and backtrace
+
+    Code
+      print(expect_error(f()))
+    Output
+      <error/rlang_error>
+      Error in `h()`:
+      ! foo
+      Backtrace:
+        1. base::print(expect_error(f()))
+        8. cli f()
+        9. cli g()
+       10. cli h()
+
+---
+
+    Code
+      print(expect_error(f(list())))
+    Output
+      <error/cli_my_class>
+      Error in `h()`:
+      ! `x` can't be empty.
+      Backtrace:
+        1. base::print(expect_error(f(list())))
+        8. cli f(list())
+        9. cli g(x)
+       10. cli h(x)
 


### PR DESCRIPTION
`cli_abort()` now takes a `call` argument set to `.envir` by default. This is not necessarily the right value, but it should always produce more helpful calls and backtraces. Here is an example where this default is correct:

```r
f <- function(x) g(x)
g <- function(x) h(x)

h <- function(x) {
  if (!length(x)) {
    classed_stop("{.arg x} can't be empty.")
  }
}
classed_stop <- function(message, env = parent.frame()) {
  cli::cli_abort(
    message,
    .envir = env,
    class = "cli_my_class"
  )
}

f(list())
#> Error in `h()`:
#> ! `x` can't be empty.
#> Run `rlang::last_error()` to see where the error occurred.

rlang::last_error()
#> <error/cli_my_class>
#> Error in `h()`:
#> ! `x` can't be empty.
#> Backtrace:
#>  1. global f(list())
#>  2. global g(x)
#>  3. global h(x)
#> Run `rlang::last_trace()` to see the full context.

rlang::last_trace()
#> <error/cli_my_class>
#> Error in `h()`:
#> ! `x` can't be empty.
#> Backtrace:
#>     ▆
#>  1. └─global f(list())
#>  2.   └─global g(x)
#>  3.     └─global h(x)
#>  4.       └─global classed_stop("{.arg x} can't be empty.")
#>  5.         └─cli::cli_abort(message, .envir = env, class = "cli_my_class")
#>  6.           └─rlang::abort(message, ..., call = call, use_cli_format = TRUE) at cli/R/rlang.R:42:2
```

`cli_abort()` now passes `use_cli_format = TRUE` so that line formatting happens lazily by having rlang call cli back at print time.

I've included backtraces in snapshots (by calling `print()` instead of `testthat::testthat_print()`) to make sure they are properly truncated. This might produce spurious diffs in the future if upstream changes in `testthat::expect_error()` induce a different backtrace structure (frame numbers might change).