### PR TITLE
check the RSTUDIO_CLI_HYPERLINKS environment variable

### DIFF
--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -54,6 +54,10 @@ ansi_has_hyperlink_support <- function() {
   enabled <- Sys.getenv("R_CLI_HYPERLINKS", "")
   if (isTRUE(as.logical(enabled))){ return(TRUE) }
 
+  ## environment variable used by RStudio
+  enabled <- Sys.getenv("RSTUDIO_CLI_HYPERLINKS", "")
+  if (isTRUE(as.logical(enabled))){ return(TRUE) }
+
   ## Are we in a terminal? No?
   if (!isatty(stdout())) { return(FALSE) }
 


### PR DESCRIPTION
closes #414 

The environment variable is set here in rstudio: 

https://github.com/rstudio/rstudio/blob/5427386efdc8352b84c28d07067b5a534bae8a5a/src/cpp/session/modules/SessionConsole.cpp#L195

I'm not sure it's worth documenting the environment variable, as it's not meant to be set by users. 