### PR TITLE
handle VTE_VERSION more robustly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # cli development version
 
+* `style_hyperlink()` no longer breaks if the env varible `VTE_VERSION`
+  is of the form `\d{4}`, i.e., 4 consecutive numbers (#441, @michaelchirico)
+
 # cli 3.2.0
 
 ## Breaking change

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -86,7 +86,10 @@ ansi_has_hyperlink_support <- function() {
       VTE_VERSION <- as.numeric(VTE_VERSION) / 100
       VTE_VERSION <- package_version(list(major = 0, minor = VTE_VERSION))
     } else {
-      VTE_VERSION <- package_version(VTE_VERSION)
+      VTE_VERSION <- package_version(VTE_VERSION, strict = FALSE)
+      if (is.na(VTE_VERSION)) {
+        VTE_VERSION <- package_version("0.1.0")
+      }
     }
     if (VTE_VERSION >= "0.50.1") return(TRUE)
   }

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -80,7 +80,15 @@ ansi_has_hyperlink_support <- function() {
   }
 
   if (nzchar(VTE_VERSION <- Sys.getenv("VTE_VERSION"))) {
-    if (package_version(VTE_VERSION) >= "0.50.1")  return(TRUE)
+    # See #441 -- some apparent heterogeneity in how the version gets
+    #   encoded to this env variable. Accept either form.
+    if (grepl("^\\d{4}$", VTE_VERSION)) {
+      VTE_VERSION <- as.numeric(VTE_VERSION) / 100
+      VTE_VERSION <- package_version(list(major = 0, minor = VTE_VERSION))
+    } else {
+      VTE_VERSION <- package_version(VTE_VERSION)
+    }
+    if (VTE_VERSION >= "0.50.1") return(TRUE)
   }
 
   FALSE


### PR DESCRIPTION
Closes #441

Happy to try and add some tests using `local_envvar()` as well but I didn't see much in the way of `style_hyperlink()` testing to imitate thus far.

As mentioned in the issue it'd be nice to have more confidence in how well this solution will hold up... maybe we should specify `major = VTE_VERSION %/% 100` instead? The only thing I could find was this:

https://github.com/GNOME/vte/blob/bbd3f97b7d40988f4a9ed1e4e8723537b3836dd0/src/vteseq.cc#L74