### PR TITLE
Pass correct `.frame` to `abort()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     mockery,
     processx,
     ps (>= 1.3.4.9000),
-    rlang (>= 1.0.2.9002),
+    rlang (>= 1.0.2.9003),
     rmarkdown,
     rstudioapi,
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cli (development version)
 
+* `cli_abort()` now supplies `.frame` to `abort()`. This fixes an
+  issue with the `.internal = TRUE` argument (r-lib/rlang#1386).
+
 * cli now does a better job at detecting the RStudio build pane, job pane
   and render pane, and their capabilities w.r.t. ANSI colors and hyperlinks.
   Note that this requires a daily build of RStudio (#465).

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -36,14 +36,16 @@
 
 cli_abort <- function(message,
                       ...,
+                      call = .envir,
                       .envir = parent.frame(),
-                      call = .envir) {
+                      .frame = .envir) {
   message[] <- vcapply(message, format_inline, .envir = .envir)
   rlang::abort(
     message,
     ...,
     call = call,
-    use_cli_format = TRUE
+    use_cli_format = TRUE,
+    .frame = .frame
   )
 }
 

--- a/man/cli_abort.Rd
+++ b/man/cli_abort.Rd
@@ -7,7 +7,13 @@
 \title{Signal an error, warning or message with a cli formatted
 message}
 \usage{
-cli_abort(message, ..., .envir = parent.frame(), call = .envir)
+cli_abort(
+  message,
+  ...,
+  call = .envir,
+  .envir = parent.frame(),
+  .frame = .envir
+)
 
 cli_warn(message, ..., .envir = parent.frame())
 
@@ -18,8 +24,6 @@ cli_inform(message, ..., .envir = parent.frame())
 
 \item{...}{Passed to \code{\link[rlang:abort]{rlang::abort()}}, \code{\link[rlang:abort]{rlang::warn()}} or
 \code{\link[rlang:abort]{rlang::inform()}}.}
-
-\item{.envir}{Environment to evaluate the glue expressions in.}
 
 \item{call}{The execution environment of a currently running
 function, e.g. \code{call = caller_env()}. The corresponding function
@@ -34,6 +38,12 @@ Can also be \code{NULL} or a \link[rlang:topic-defuse]{defused function call} to
 respectively not display any call or hard-code a code to display.
 
 For more information about error calls, see \ifelse{html}{\link[rlang:topic-error-call]{Including function calls in error messages}}{\link[rlang:topic-error-call]{Including function calls in error messages}}.}
+
+\item{.envir}{Environment to evaluate the glue expressions in.}
+
+\item{.frame}{The throwing context. Used as default for
+\code{.trace_bottom}, and to determine the internal package to mention
+in internal errors when \code{.internal} is \code{TRUE}.}
 }
 \description{
 These functions let you create error, warning or diagnostic

--- a/tests/testthat/_snaps/rlang-errors.md
+++ b/tests/testthat/_snaps/rlang-errors.md
@@ -479,3 +479,13 @@
         9. cli (local) g(x)
        10. cli (local) h(x)
 
+# cli_abort(.internal = TRUE) reports the correct function (r-lib/rlang#1386)
+
+    Code
+      (expect_error(fn()))
+    Output
+      <error/rlang_error>
+      Error in `fn()`:
+      ! Message.
+      i This is an internal error in the base package, please report it to the package authors.
+

--- a/tests/testthat/test-rlang-errors.R
+++ b/tests/testthat/test-rlang-errors.R
@@ -195,3 +195,15 @@ test_that("cli_abort() captures correct call and backtrace", {
     print(expect_error(f(list())))
   })
 })
+
+test_that("cli_abort(.internal = TRUE) reports the correct function (r-lib/rlang#1386)", {
+  fn <- function() {
+    cli::cli_abort("Message.", .internal = TRUE)
+  }
+  environment(fn) <- rlang::ns_env("base")
+
+  # Should mention an internal error in the `base` package
+  expect_snapshot({
+    (expect_error(fn()))
+  })
+})


### PR DESCRIPTION
Depends on https://github.com/r-lib/rlang/commit/9ed2c628fbd3c9e279b557872231f9f9014edc59.
Closes r-lib/rlang#1386.