### PR TITLE
refer to `main` instead of `master` in the docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Remotes:
     r-lib/rlang
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.1.2.9000
+RoxygenNote: 7.2.0

--- a/R/rstudio-detect.R
+++ b/R/rstudio-detect.R
@@ -159,7 +159,7 @@ rstudio <- local({
                new$envs[["R_PDFVIEWER"]] == "false" &&
                is_build_pane_command(new$args)) {
       # 5. R in the RStudio build pane
-      # https://github.com/rstudio/rstudio/blob/master/src/cpp/session/
+      # https://github.com/rstudio/rstudio/blob/main/src/cpp/session/
       # modules/build/SessionBuild.cpp#L231-L240
       "rstudio_build_pane"
 

--- a/R/test.R
+++ b/R/test.R
@@ -15,9 +15,9 @@
 #' * `fancy`; ANSI colors, Unicode characters.
 #'
 #' See examples below and in cli's own tests, e.g. in
-#' <https://github.com/cran/cli/tree/master/tests/testthat>
+#' <https://github.com/cran/cli/tree/main/tests/testthat>
 #' and the corresponding snapshots at
-#' <https://github.com/cran/cli/tree/master/tests/testthat/_snaps>
+#' <https://github.com/cran/cli/tree/main/tests/testthat/_snaps>
 #'
 #' ## Important note regarding Windows
 #'

--- a/R/test.R
+++ b/R/test.R
@@ -15,9 +15,9 @@
 #' * `fancy`; ANSI colors, Unicode characters.
 #'
 #' See examples below and in cli's own tests, e.g. in
-#' <https://github.com/cran/cli/tree/main/tests/testthat>
+#' <https://github.com/r-lib/cli/tree/main/tests/testthat>
 #' and the corresponding snapshots at
-#' <https://github.com/cran/cli/tree/main/tests/testthat/_snaps>
+#' <https://github.com/r-lib/cli/tree/main/tests/testthat/_snaps>
 #'
 #' ## Important note regarding Windows
 #'

--- a/man/test_that_cli.Rd
+++ b/man/test_that_cli.Rd
@@ -36,9 +36,9 @@ Currently available configurations:
 }
 
 See examples below and in cli's own tests, e.g. in
-\url{https://github.com/cran/cli/tree/main/tests/testthat}
+\url{https://github.com/r-lib/cli/tree/main/tests/testthat}
 and the corresponding snapshots at
-\url{https://github.com/cran/cli/tree/main/tests/testthat/_snaps}
+\url{https://github.com/r-lib/cli/tree/main/tests/testthat/_snaps}
 \subsection{Important note regarding Windows}{
 
 Because of base R's limitation to record Unicode characters on Windows,

--- a/man/test_that_cli.Rd
+++ b/man/test_that_cli.Rd
@@ -36,9 +36,9 @@ Currently available configurations:
 }
 
 See examples below and in cli's own tests, e.g. in
-\url{https://github.com/cran/cli/tree/master/tests/testthat}
+\url{https://github.com/cran/cli/tree/main/tests/testthat}
 and the corresponding snapshots at
-\url{https://github.com/cran/cli/tree/master/tests/testthat/_snaps}
+\url{https://github.com/cran/cli/tree/main/tests/testthat/_snaps}
 \subsection{Important note regarding Windows}{
 
 Because of base R's limitation to record Unicode characters on Windows,


### PR DESCRIPTION
Needed to bump the roxygen2 version to also update the `.Rd` files.

I don't know if there is any specific reason that the URLs were directed to CRAN mirror rather than the GitHub repo. If there is, feel free to close the PR since it's irrelevant in that case.