### PR TITLE
Fallback to a default `code_highlight()` theme if RStudio theme is unavailable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Remotes:
     r-lib/rlang
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.1.2.9000
+RoxygenNote: 7.2.1.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cli (development version)
 
+* `code_highlight` now falls to the default theme (instead of no theme) for
+  unknown RStudio themes (#482, @rossellhayes).
+
 * `cli_abort()` now supplies `.frame` to `abort()`. This fixes an
   issue with the `.internal = TRUE` argument (r-lib/rlang#1386).
 

--- a/R/prettycode.R
+++ b/R/prettycode.R
@@ -267,7 +267,7 @@ code_theme_default_rstudio <- function() {
   theme <- rstudioapi::getThemeInfo()$editor
   if (! theme %in% names(rstudio_themes)) {
     warning("cli does not know this RStudio theme: ", theme)
-    return(list())
+    return(code_theme_default_term())
   }
   rstudio_themes[[theme]]
 }

--- a/R/prettycode.R
+++ b/R/prettycode.R
@@ -266,7 +266,13 @@ code_theme_make <- function(theme) {
 code_theme_default_rstudio <- function() {
   theme <- rstudioapi::getThemeInfo()$editor
   if (! theme %in% names(rstudio_themes)) {
-    warning("cli does not know this RStudio theme: ", theme)
+    if (!getOption("cli.ignore_unknown_rstudio_theme", FALSE)) {
+      warning(
+        "cli does not know this RStudio theme: '", theme, "'.",
+        "\nSet `options(cli.ignore_unknown_rstudio_theme = TRUE)` ",
+        "to suppress this warning"
+      )
+    }
     return(code_theme_default_term())
   }
   rstudio_themes[[theme]]

--- a/tests/testthat/test-prettycode.R
+++ b/tests/testthat/test-prettycode.R
@@ -215,7 +215,7 @@ test_that("code_theme_default_rstudio", {
     cth <- code_theme_default_rstudio(),
     "cli does not know this RStudio theme"
   )
-  expect_equal(cth, list())
+  expect_equal(cth, code_theme_default_term())
 })
 
 test_that("code_theme_list", {

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -94,6 +94,11 @@ ANSI hyperlinks.
 Set to anything else to assume no hyperlink support.
 See [style_hyperlink()].
 
+### `cli.ignore_unknown_rstudio_theme`
+
+Set to `TRUE` to omit a warning for an unknown RStudio theme in
+`code_highlight()`.
+
 ### `cli.num_colors`
 
 Number of ANSI colors. See [num_ansi_colors()]. See also the


### PR DESCRIPTION
If `code_theme_default_rstudio()` is unavailable, `code_highlight()` falls back to `code_theme_default_term()`:

<img width="959" alt="Screen Shot 2022-06-15 at 12 34 06 PM" src="https://user-images.githubusercontent.com/44556601/173909891-0f7c0620-089e-4001-8849-df961ff01c2d.png">

I opted to use the default terminal theme instead of an RStudio theme, because the existing RStudio themes were probably designed with a specific background color in mind.

I also preserved the existing warning message if the theme is unrecognized, but this could be removed if it is no longer considered necessary.

Closes #481.