### PR TITLE
Use escape code 49 to close `bg_br_*` ANSI styles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@
   E.g. the meaning of `"{.emph +1}"` is now always the "+1", with style
   `.emph`, even if an `.emph` variable is available and the `.emph + 1`
   expresion can be evaluated.
+  
+* Functions that apply bright background colors (e.g. `bg_br_yellow()`) now 
+  close themselves. They no longer format text after the end of the function
+  (#484, @rossellhayes).
 
 # cli 3.3.0
 

--- a/R/ansi.R
+++ b/R/ansi.R
@@ -55,14 +55,14 @@ ansi_builtin_styles <- list(
   bg_cyan = palette_color(list(46, 49)),
   bg_white = palette_color(list(47, 49)),
 
-  bg_br_black = palette_color(list(100, 39)),
-  bg_br_red = palette_color(list(101, 39)),
-  bg_br_green = palette_color(list(102, 39)),
-  bg_br_yellow = palette_color(list(103, 39)),
-  bg_br_blue = palette_color(list(104, 39)),
-  bg_br_magenta = palette_color(list(105, 39)),
-  bg_br_cyan = palette_color(list(106, 39)),
-  bg_br_white = palette_color(list(107, 39)),
+  bg_br_black = palette_color(list(100, 49)),
+  bg_br_red = palette_color(list(101, 49)),
+  bg_br_green = palette_color(list(102, 49)),
+  bg_br_yellow = palette_color(list(103, 49)),
+  bg_br_blue = palette_color(list(104, 49)),
+  bg_br_magenta = palette_color(list(105, 49)),
+  bg_br_cyan = palette_color(list(106, 49)),
+  bg_br_white = palette_color(list(107, 49)),
 
   # similar to reset, but only for a single property
   no_bold          = list(c(0,     23, 24, 27, 28, 29, 39, 49), 22),


### PR DESCRIPTION
`bg_br_*` ANSI styles previously closed with escape code 39, which restores the default foreground color, rather than escape code 49, which restores the default background color.

This PR fixes the escape code to allow the `bg_br_*()` functions to properly close themselves:

<img width="597" src="https://user-images.githubusercontent.com/44556601/174240640-06eaa7f8-2497-4221-898b-46e15a7490f9.png">

Closes #484.