### PR TITLE
Use embedded glue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /r-packages
 /README_cache
 /README_files
-docs/
+/docs/
 inst/doc
 doc
 Meta

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ Config/Needs/website:
     vctrs
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.2.0.9000
+RoxygenNote: 7.2.1.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,12 +19,12 @@ BugReports: https://github.com/r-lib/cli/issues
 Depends: 
     R (>= 3.4)
 Imports:
-    glue (>= 1.6.0),
     utils
 Suggests:
     callr,
     covr,
     digest,
+    glue (>= 1.6.0),
     grDevices,
     htmltools,
     htmlwidgets,

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -25,9 +25,12 @@
 #' cat("This is an", style_hyperlink("R", "https://r-project.org"), "link.\n")
 
 style_hyperlink <- function(text, url, params = NULL) {
-  params <- glue::glue_collapse(sep = ":",
-    glue::glue("{names(params)}={params}")
-  )
+  params <- if (length(params)) {
+    paste(
+      names(params), "=", params,
+      collapse = ":"
+    )
+  }
 
   ST <- "\u0007"
 

--- a/R/bullets.R
+++ b/R/bullets.R
@@ -68,7 +68,7 @@ cli_bullets <- function(text, id = NULL, class = NULL,
 #' `cli_format_bullets_raw()` is similar to [cli_bullets()], but it does
 #' not perform any inline styling or glue substitutions in the input.
 #'
-#' `format_bullets_raw()` returned the output instead of printing it.
+#' `format_bullets_raw()` returns the output instead of printing it.
 #'
 #' @param text Character vector of items. See details below on how names
 #' are interpreted.

--- a/R/containers.R
+++ b/R/containers.R
@@ -172,9 +172,9 @@ clii__item_text <- function(app, type, name, cnt_id, text, .list) {
     res
   } else if (type == "dl") {
     mrk <- text$values$marker
-    text$str <- paste0("<", mrk, ".dd ", text$str, mrk, ">")
+    text$str <- paste0("{", mrk, ".dd ", text$str, mrk, "}")
     mrk2 <- head$values$marker
-    paste0("<", mrk2, ".dt ", head$str, mrk2, ">")
+    paste0("{", mrk2, ".dt ", head$str, mrk2, "}")
   }
 
   app$xtext(

--- a/R/containers.R
+++ b/R/containers.R
@@ -172,9 +172,9 @@ clii__item_text <- function(app, type, name, cnt_id, text, .list) {
     res
   } else if (type == "dl") {
     mrk <- text$values$marker
-    text$str <- paste0("{", mrk, ".dd ", text$str, mrk, "}")
+    text$str <- paste0("<", mrk, ".dd ", text$str, mrk, ">")
     mrk2 <- head$values$marker
-    paste0("{", mrk2, ".dt ", head$str, mrk2, "}")
+    paste0("<", mrk2, ".dt ", head$str, mrk2, ">")
   }
 
   app$xtext(

--- a/R/format.R
+++ b/R/format.R
@@ -90,7 +90,7 @@ cli_format.numeric <- function(x, style = NULL, ...) {
 #'
 #' @details
 #' You can use this function to change the default parameters of
-#' [glue::glue_collapse()], see an example below.
+#' collapsing the vector into a string, see an example below.
 #'
 #' The style is added as an attribute, so operations that remove
 #' attributes will remove the style as well.
@@ -115,8 +115,7 @@ cli_format.numeric <- function(x, style = NULL, ...) {
 #' @param x Vector that will be collapsed by cli.
 #' @param style Style to apply to the vector. It is used as a theme on
 #' a `span` element that is created for the vector. You can set `vec_sep`
-#' and `vec_last` to modify the `sep` and `last` arguments of
-#' [glue::glue_collapse()]. See an example below.
+#' and `vec_last` to modify the separator and the last separator.
 #'
 #' @export
 #' @seealso [cli_format()]

--- a/R/glue.R
+++ b/R/glue.R
@@ -3,6 +3,7 @@
 # - .sep = ""
 # - .trim = TRUE
 # - .null = character()
+# - .literal = TRUE
 # - .comment = ""
 #
 # we also don't allow passing in data as arguments, and `text` is
@@ -10,7 +11,7 @@
 
 glue <- function(text, .envir = parent.frame(),
                  .transformer = identity_transformer,
-                 .open = "{", .close = "}", .literal = NA) {
+                 .open = "{", .close = "}") {
 
   text <- paste0(text, collapse = "")
 
@@ -28,7 +29,7 @@ glue <- function(text, .envir = parent.frame(),
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
   }
 
-  res <- .Call(glue_, text, f, .open, .close, .literal)
+  res <- .Call(glue_, text, f, .open, .close)
 
   res <- drop_null(res)
   if (any(lengths(res) == 0)) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -48,3 +48,16 @@ identity_transformer <- function (text, envir) {
 drop_null <- function(x) {
   x[!vapply(x, is.null, logical(1))]
 }
+
+glue_collapse <- function(x, sep = "", last = "") {
+  if (length(x) == 0) {
+    character()
+  } else if (any(is.na(x))) {
+    NA_character_
+  } else if (nzchar(last) && length(x) > 1) {
+    res <- glue_collapse(x[seq(1, length(x) - 1)], sep = sep)
+    glue_collapse(paste0(res, last, x[length(x)]))
+  } else {
+    paste0(x, collapse = sep)
+  }
+}

--- a/R/glue.R
+++ b/R/glue.R
@@ -23,7 +23,7 @@ glue <- function(text, .envir = parent.frame(),
     return(text)
   }
 
-  text <- glue::trim(text)
+  text <- trim(text)
 
   f <- function(expr) {
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
@@ -60,4 +60,12 @@ glue_collapse <- function(x, sep = "", last = "") {
   } else {
     paste0(x, collapse = sep)
   }
+}
+
+trim <- function (x) {
+  has_newline <- function(x) any(grepl("\\n", x))
+  if (length(x) == 0 || !has_newline(x)) {
+    return(x)
+  }
+  .Call(trim_, x)
 }

--- a/R/glue.R
+++ b/R/glue.R
@@ -10,7 +10,7 @@
 
 glue <- function(text, .envir = parent.frame(),
                  .transformer = identity_transformer,
-                 .open = "{", .close = "}", .literal = NA) {
+                 .open = "{", .close = "}", .round) {
 
   text <- paste0(text, collapse = "")
 
@@ -28,7 +28,7 @@ glue <- function(text, .envir = parent.frame(),
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
   }
 
-  res <- .Call(glue_, text, f, .open, .close, .literal)
+  res <- .Call(glue_, text, f, .open, .close, as.integer(.round))
 
   res <- drop_null(res)
   if (any(lengths(res) == 0)) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -11,7 +11,7 @@
 
 glue <- function(text, .envir = parent.frame(),
                  .transformer = identity_transformer,
-                 .open = "{", .close = "}") {
+                 .open = "{", .close = "}", .cli = FALSE) {
 
   text <- paste0(text, collapse = "")
 
@@ -29,7 +29,7 @@ glue <- function(text, .envir = parent.frame(),
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
   }
 
-  res <- .Call(glue_, text, f, .open, .close)
+  res <- .Call(glue_, text, f, .open, .close, .cli)
 
   res <- drop_null(res)
   if (any(lengths(res) == 0)) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -1,0 +1,50 @@
+
+# Compared to glue::glue(), these are fixed:
+# - .sep = ""
+# - .trim = TRUE
+# - .null = character()
+# - .literal = TRUE
+# - .comment = ""
+#
+# we also don't allow passing in data as arguments, and `text` is
+# a single argument, no need to `paste()` etc.
+
+glue <- function(text, .envir = parent.frame(),
+                 .transformer = identity_transformer,
+                 .open = "{", .close = "}") {
+
+  text <- paste0(text, collapse = "")
+
+  if (length(text) < 1) {
+    return(text)
+  }
+
+  if (is.na(text)) {
+    return(text)
+  }
+
+  text <- glue::trim(text)
+
+  f <- function(expr) {
+    eval_func <- as.character(.transformer(expr, .envir) %||% character())
+  }
+
+  res <- .Call(glue_, text, f, .open, .close)
+
+  res <- drop_null(res)
+  if (any(lengths(res) == 0)) {
+    return(character(0))
+  }
+
+  res[] <- lapply(res, function(x) replace(x, is.na(x), "NA"))
+
+  do.call(paste0, res)
+}
+
+identity_transformer <- function (text, envir) {
+  eval(parse(text = text, keep.source = FALSE), envir)
+}
+
+drop_null <- function(x) {
+  x[!vapply(x, is.null, logical(1))]
+}

--- a/R/glue.R
+++ b/R/glue.R
@@ -10,7 +10,7 @@
 
 glue <- function(text, .envir = parent.frame(),
                  .transformer = identity_transformer,
-                 .open = "{", .close = "}", .round) {
+                 .open = "{", .close = "}", .literal = NA) {
 
   text <- paste0(text, collapse = "")
 
@@ -28,7 +28,7 @@ glue <- function(text, .envir = parent.frame(),
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
   }
 
-  res <- .Call(glue_, text, f, .open, .close, as.integer(.round))
+  res <- .Call(glue_, text, f, .open, .close, .literal)
 
   res <- drop_null(res)
   if (any(lengths(res) == 0)) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -3,7 +3,6 @@
 # - .sep = ""
 # - .trim = TRUE
 # - .null = character()
-# - .literal = TRUE
 # - .comment = ""
 #
 # we also don't allow passing in data as arguments, and `text` is
@@ -11,7 +10,7 @@
 
 glue <- function(text, .envir = parent.frame(),
                  .transformer = identity_transformer,
-                 .open = "{", .close = "}") {
+                 .open = "{", .close = "}", .literal = NA) {
 
   text <- paste0(text, collapse = "")
 
@@ -29,7 +28,7 @@ glue <- function(text, .envir = parent.frame(),
     eval_func <- as.character(.transformer(expr, .envir) %||% character())
   }
 
-  res <- .Call(glue_, text, f, .open, .close)
+  res <- .Call(glue_, text, f, .open, .close, .literal)
 
   res <- drop_null(res)
   if (any(lengths(res) == 0)) {

--- a/R/inline.R
+++ b/R/inline.R
@@ -128,7 +128,7 @@ inline_transformer <- function(code, envir) {
     # but only to the whole non-brace expression. We don't need to end this
     # container, because the one above (`id`) will end this one as well.
 
-    braceexp <- grepl("^[{][^.][^}]*[}]$", text)
+    braceexp <- grepl("^[<][^.][^}]*[>]$", text)
     if (!braceexp) {
       id2 <- clii__container_start(app, "span", class = NULL)
     }
@@ -137,8 +137,8 @@ inline_transformer <- function(code, envir) {
       text,
       .envir = envir,
       .transformer = inline_transformer,
-      .open = paste0("{", envir$marker),
-      .close = paste0(envir$marker, "}")
+      .open = paste0("<", envir$marker),
+      .close = paste0(envir$marker, ">")
     )
 
     # If we don't have a brace expression, then (non-inherited) styling was
@@ -216,8 +216,8 @@ clii__inline <- function(app, text, .list) {
       t$str,
       .envir = t$values,
       .transformer = inline_transformer,
-      .open = paste0("{", t$values$marker),
-      .close = paste0(t$values$marker, "}")
+      .open = paste0("<", t$values$marker),
+      .close = paste0(t$values$marker, ">")
     )
   })
   paste(out, collapse = "")
@@ -245,7 +245,7 @@ make_cmd_transformer <- function(values) {
       values[[id]] <- res
       values$qty <- res
       values$num_subst <- values$num_subst + 1L
-      return(paste0("{", values$marker, id, values$marker, "}"))
+      return(paste0("<", values$marker, id, values$marker, ">"))
     }
 
     # plurals
@@ -269,7 +269,7 @@ make_cmd_transformer <- function(values) {
         .envir = envir,
         .transformer = sys.function()
       )
-      paste0("{", values$marker, ".", funname, " ", out, values$marker, "}")
+      paste0("<", values$marker, ".", funname, " ", out, values$marker, ">")
     }
   }
 }

--- a/R/inline.R
+++ b/R/inline.R
@@ -46,7 +46,7 @@ inline_collapse <- function(x, style = list()) {
     x <- c(x[1:trunc], cli::symbol$ellipsis)
     last <- sep
   }
-  glue::glue_collapse(as.character(x), sep = sep, last = last)
+  glue_collapse(as.character(x), sep = sep, last = last)
 }
 
 #' This glue transformer performs the inline styling of cli

--- a/R/inline.R
+++ b/R/inline.R
@@ -133,14 +133,12 @@ inline_transformer <- function(code, envir) {
       id2 <- clii__container_start(app, "span", class = NULL)
     }
 
-    out <- glue::glue(
+    out <- glue(
       text,
       .envir = envir,
       .transformer = inline_transformer,
       .open = paste0("{", envir$marker),
-      .close = paste0(envir$marker, "}"),
-      .trim = TRUE,
-      .comment = ""
+      .close = paste0(envir$marker, "}")
     )
 
     # If we don't have a brace expression, then (non-inherited) styling was
@@ -214,14 +212,12 @@ clii__inline <- function(app, text, .list) {
   texts <- c(if (!is.null(text)) list(text), .list)
   out <- lapply(texts, function(t) {
     t$values$app <- app
-    glue::glue(
+    glue(
       t$str,
       .envir = t$values,
       .transformer = inline_transformer,
       .open = paste0("{", t$values$marker),
-      .close = paste0(t$values$marker, "}"),
-      .trim = TRUE,
-      .comment = ""
+      .close = paste0(t$values$marker, "}")
     )
   })
   paste(out, collapse = "")
@@ -268,12 +264,10 @@ make_cmd_transformer <- function(values) {
       funname <- captures[[1]]
       text <- captures[[2]]
 
-      out <- glue::glue(
+      out <- glue(
         text,
         .envir = envir,
-        .transformer = sys.function(),
-        .trim = TRUE,
-        .comment = ""
+        .transformer = sys.function()
       )
       paste0("{", values$marker, ".", funname, " ", out, values$marker, "}")
     }
@@ -284,12 +278,10 @@ glue_cmd <- function(..., .envir) {
   str <- paste0(unlist(list(...), use.names = FALSE), collapse = "")
   values <- new.env(parent = emptyenv())
   transformer <- make_cmd_transformer(values)
-  pstr <- glue::glue(
+  pstr <- glue(
     str,
     .envir = .envir,
-    .transformer = transformer,
-    .trim = TRUE,
-    .comment = ""
+    .transformer = transformer
   )
   glue_delay(
     str = post_process_plurals(pstr, values),

--- a/R/inline.R
+++ b/R/inline.R
@@ -138,7 +138,8 @@ inline_transformer <- function(code, envir) {
       .envir = envir,
       .transformer = inline_transformer,
       .open = paste0("{", envir$marker),
-      .close = paste0(envir$marker, "}")
+      .close = paste0(envir$marker, "}"),
+      .literal = TRUE
     )
 
     # If we don't have a brace expression, then (non-inherited) styling was
@@ -217,7 +218,8 @@ clii__inline <- function(app, text, .list) {
       .envir = t$values,
       .transformer = inline_transformer,
       .open = paste0("{", t$values$marker),
-      .close = paste0(t$values$marker, "}")
+      .close = paste0(t$values$marker, "}"),
+      .literal = TRUE
     )
   })
   paste(out, collapse = "")
@@ -233,30 +235,13 @@ make_cmd_transformer <- function(values) {
   values$pmarkers <- list()
 
   function(code, envir) {
-    res <- tryCatch({
-      if (substr(code, 1, 1) == ".") stop("style")
-      expr <- parse(text = code, keep.source = FALSE)
-      eval(expr, envir = list("?" = function(...) stop()), enclos = envir)
-    }, error = function(e) e)
 
-    if (!inherits(res, "error")) {
-      id <- paste0("v", length(values))
-      if (length(res) == 0) res <- qty(0)
-      values[[id]] <- res
-      values$qty <- res
-      values$num_subst <- values$num_subst + 1L
-      return(paste0("{", values$marker, id, values$marker, "}"))
-    }
-
-    # plurals
-    if (substr(code, 1, 1) == "?") {
-      return(parse_plural(code, values))
-
-    } else {
-      # inline styles
+    first <- substr(code, 1, 1)
+    if (first == ".") {
+      # style
       m <- regexpr(inline_regex(), code, perl = TRUE)
       has_match <- m != -1
-      if (!has_match) stop(res)
+      if (!has_match) stop("Invalid cli style string: `", code, "`")
 
       starts <- attr(m, "capture.start")
       ends <- starts + attr(m, "capture.length") - 1L
@@ -270,6 +255,21 @@ make_cmd_transformer <- function(values) {
         .transformer = sys.function()
       )
       paste0("{", values$marker, ".", funname, " ", out, values$marker, "}")
+
+    } else if (first == "?") {
+      # plural
+      parse_plural(code, values)
+
+    } else {
+      # plain glue
+      expr <- parse(text = code, keep.source = FALSE)
+      res <- eval(expr, envir = list("?" = function(...) stop()), enclos = envir)
+      id <- paste0("v", length(values))
+      if (length(res) == 0) res <- qty(0)
+      values[[id]] <- res
+      values$qty <- res
+      values$num_subst <- values$num_subst + 1L
+      paste0("{", values$marker, id, values$marker, "}")
     }
   }
 }
@@ -278,11 +278,17 @@ glue_cmd <- function(..., .envir) {
   str <- paste0(unlist(list(...), use.names = FALSE), collapse = "")
   values <- new.env(parent = emptyenv())
   transformer <- make_cmd_transformer(values)
+
+  # first we parse the {. ... } expressions, these can be nested, so we
+  # get all of them.
   pstr <- glue(
     str,
     .envir = .envir,
     .transformer = transformer
   )
+
+  # then we do the {? ... } expressions for pluralization
+
   glue_delay(
     str = post_process_plurals(pstr, values),
     values = values

--- a/R/inline.R
+++ b/R/inline.R
@@ -267,7 +267,8 @@ make_cmd_transformer <- function(values) {
       out <- glue(
         text,
         .envir = envir,
-        .transformer = sys.function()
+        .transformer = sys.function(),
+        .cli = TRUE
       )
       paste0("<", values$marker, ".", funname, " ", out, values$marker, ">")
     }
@@ -281,7 +282,8 @@ glue_cmd <- function(..., .envir) {
   pstr <- glue(
     str,
     .envir = .envir,
-    .transformer = transformer
+    .transformer = transformer,
+    .cli = TRUE
   )
   glue_delay(
     str = post_process_plurals(pstr, values),

--- a/R/inline.R
+++ b/R/inline.R
@@ -128,7 +128,7 @@ inline_transformer <- function(code, envir) {
     # but only to the whole non-brace expression. We don't need to end this
     # container, because the one above (`id`) will end this one as well.
 
-    braceexp <- grepl("^[<][^.][^>]*[>]$", text)
+    braceexp <- grepl("^[{][^.][^}]*[}]$", text)
     if (!braceexp) {
       id2 <- clii__container_start(app, "span", class = NULL)
     }
@@ -137,9 +137,9 @@ inline_transformer <- function(code, envir) {
       text,
       .envir = envir,
       .transformer = inline_transformer,
-      .open = paste0("<", envir$marker),
-      .close = paste0(envir$marker, ">"),
-      .round = 3L
+      .open = paste0("{", envir$marker),
+      .close = paste0(envir$marker, "}"),
+      .literal = TRUE
     )
 
     # If we don't have a brace expression, then (non-inherited) styling was
@@ -217,9 +217,9 @@ clii__inline <- function(app, text, .list) {
       t$str,
       .envir = t$values,
       .transformer = inline_transformer,
-      .open = paste0("<", t$values$marker),
-      .close = paste0(t$values$marker, ">"),
-      .round = 3L
+      .open = paste0("{", t$values$marker),
+      .close = paste0(t$values$marker, "}"),
+      .literal = TRUE
     )
   })
   paste(out, collapse = "")
@@ -252,11 +252,9 @@ make_cmd_transformer <- function(values) {
       out <- glue(
         text,
         .envir = envir,
-        .transformer = sys.function(),
-        # nesting can only happen in round 2
-        .round = 2L
+        .transformer = sys.function()
       )
-      paste0("<", values$marker, ".", funname, " ", out, values$marker, ">")
+      paste0("{", values$marker, ".", funname, " ", out, values$marker, "}")
 
     } else if (first == "?") {
       # plural
@@ -271,7 +269,7 @@ make_cmd_transformer <- function(values) {
       values[[id]] <- res
       values$qty <- res
       values$num_subst <- values$num_subst + 1L
-      paste0("<", values$marker, id, values$marker, ">")
+      paste0("{", values$marker, id, values$marker, "}")
     }
   }
 }
@@ -281,24 +279,18 @@ glue_cmd <- function(..., .envir) {
   values <- new.env(parent = emptyenv())
   transformer <- make_cmd_transformer(values)
 
-  # first we parse the {} and {?} expressions, these cannot be nested
+  # first we parse the {. ... } expressions, these can be nested, so we
+  # get all of them.
   pstr <- glue(
     str,
     .envir = .envir,
-    .transformer = transformer,
-    .round = 1L,
+    .transformer = transformer
   )
 
-  # then we parse the {.} style expressions
-  pstr2 <- glue(
-    pstr,
-    .envir = .envir,
-    .transformer = transformer,
-    .round = 2L,
-  )
+  # then we do the {? ... } expressions for pluralization
 
   glue_delay(
-    str = post_process_plurals(pstr2, values),
+    str = post_process_plurals(pstr, values),
     values = values
   )
 }

--- a/R/pluralize.R
+++ b/R/pluralize.R
@@ -116,11 +116,13 @@ post_process_plurals <- function(str, values) {
 #'
 #' See [pluralization] and some examples below.
 #'
+#' You need to install the glue package to use this function.
+#'
 #' @param ...,.envir,.transformer All arguments are passed to [glue::glue()].
 #'
 #' @export
 #' @family pluralization
-#' @examples
+#' @examplesIf requireNamespace("glue", quietly = TRUE)
 #' # Regular plurals
 #' nfile <- 0; pluralize("Found {nfile} file{?s}.")
 #' nfile <- 1; pluralize("Found {nfile} file{?s}.")

--- a/man/cli_abort.Rd
+++ b/man/cli_abort.Rd
@@ -41,12 +41,9 @@ For more information about error calls, see \ifelse{html}{\link[rlang:topic-erro
 
 \item{.envir}{Environment to evaluate the glue expressions in.}
 
-\item{.frame}{The throwing context. Defaults to \code{call} if it is an
-environment, \code{\link[rlang:caller_env]{caller_env()}} otherwise. This is used in the
-display of simplified backtraces as the last relevant call frame
-to show. This way, the irrelevant parts of backtraces
-corresponding to condition handling (\code{\link[=tryCatch]{tryCatch()}}, \code{\link[rlang:try_fetch]{try_fetch()}},
-\code{abort()}, etc.) are hidden by default.}
+\item{.frame}{The throwing context. Used as default for
+\code{.trace_bottom}, and to determine the internal package to mention
+in internal errors when \code{.internal} is \code{TRUE}.}
 }
 \description{
 These functions let you create error, warning or diagnostic

--- a/man/cli_bullets_raw.Rd
+++ b/man/cli_bullets_raw.Rd
@@ -22,7 +22,7 @@ are interpreted.}
 not perform any inline styling or glue substitutions in the input.
 }
 \details{
-\code{format_bullets_raw()} returned the output instead of printing it.
+\code{format_bullets_raw()} returns the output instead of printing it.
 }
 \seealso{
 See \code{\link[=cli_bullets]{cli_bullets()}} for examples.

--- a/man/cli_vec.Rd
+++ b/man/cli_vec.Rd
@@ -11,15 +11,14 @@ cli_vec(x, style = list())
 
 \item{style}{Style to apply to the vector. It is used as a theme on
 a \code{span} element that is created for the vector. You can set \code{vec_sep}
-and \code{vec_last} to modify the \code{sep} and \code{last} arguments of
-\code{\link[glue:glue_collapse]{glue::glue_collapse()}}. See an example below.}
+and \code{vec_last} to modify the separator and the last separator.}
 }
 \description{
 Add custom cli style to a vector
 }
 \details{
 You can use this function to change the default parameters of
-\code{\link[glue:glue_collapse]{glue::glue_collapse()}}, see an example below.
+collapsing the vector into a string, see an example below.
 
 The style is added as an attribute, so operations that remove
 attributes will remove the style as well.

--- a/man/pluralize.Rd
+++ b/man/pluralize.Rd
@@ -22,8 +22,11 @@ pluralize(
 }
 \details{
 See \link{pluralization} and some examples below.
+
+You need to install the glue package to use this function.
 }
 \examples{
+\dontshow{if (requireNamespace("glue", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Regular plurals
 nfile <- 0; pluralize("Found {nfile} file{?s}.")
 nfile <- 1; pluralize("Found {nfile} file{?s}.")
@@ -56,6 +59,7 @@ pluralize("Found {nfiles} file{?s} and {ndirs} director{?y/ies}")
 # Explicit quantities
 nupd <- 3; ntotal <- 10
 cli_text("{nupd}/{ntotal} {qty(nupd)} file{?s} {?needs/need} updates")
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 Other pluralization: 

--- a/src/cli.h
+++ b/src/cli.h
@@ -121,6 +121,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               uint8_t **ptr,
                               int *width);
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg);
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg);
 
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -121,6 +121,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               uint8_t **ptr,
                               int *width);
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg);
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg);
 
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -121,6 +121,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               uint8_t **ptr,
                               int *width);
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg);
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg);
 
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -122,5 +122,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               int *width);
 
 SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg);
+SEXP trim_(SEXP x);
 
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -121,6 +121,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               uint8_t **ptr,
                               int *width);
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg);
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg);
 
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -121,4 +121,6 @@ void clic_utf8_graphscan_next(struct grapheme_iterator *iter,
                               uint8_t **ptr,
                               int *width);
 
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg);
+
 #endif

--- a/src/glue.c
+++ b/src/glue.c
@@ -1,0 +1,213 @@
+
+#define STRICT_R_HEADERS
+#define R_NO_REMAP
+#include "Rinternals.h"
+#include <stdlib.h>
+#include <string.h>
+
+SEXP set(SEXP x, int i, SEXP val) {
+  R_xlen_t len = Rf_xlength(x);
+  if (i >= len) {
+    len *= 2;
+    x = Rf_lengthgets(x, len);
+  }
+  SET_VECTOR_ELT(x, i, val);
+  return x;
+}
+
+SEXP resize(SEXP out, R_xlen_t n) {
+  if (n == Rf_xlength(out)) {
+    return out;
+  }
+  return Rf_xlengthgets(out, n);
+}
+
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
+
+  typedef enum {
+    text,
+    escape,
+    single_quote,
+    double_quote,
+    backtick,
+    delim,
+    comment
+  } states;
+
+  const char* xx = Rf_translateCharUTF8(STRING_ELT(x, 0));
+  size_t str_len = strlen(xx);
+
+  char* str = (char*)malloc(str_len + 1);
+
+  const char* open = CHAR(STRING_ELT(open_arg, 0));
+  size_t open_len = strlen(open);
+
+  const char* close = CHAR(STRING_ELT(close_arg, 0));
+  size_t close_len = strlen(close);
+
+  char comment_char = '\0';
+
+  Rboolean literal = 1;
+
+  int delim_equal = strncmp(open, close, open_len) == 0;
+
+  SEXP out = Rf_allocVector(VECSXP, 1);
+  PROTECT_INDEX out_idx;
+  PROTECT_WITH_INDEX(out, &out_idx);
+
+  size_t j = 0;
+  size_t k = 0;
+  int delim_level = 0;
+  size_t start = 0;
+  states state = text;
+  states prev_state = text;
+  size_t i = 0;
+  for (i = 0; i < str_len; ++i) {
+    switch (state) {
+    case text: {
+      if (strncmp(&xx[i], open, open_len) == 0) {
+        /* check for open delim doubled */
+        if (strncmp(&xx[i + open_len], open, open_len) == 0) {
+          i += open_len;
+        } else {
+          state = delim;
+          delim_level = 1;
+          start = i + open_len;
+          break;
+        }
+      }
+      if (strncmp(&xx[i], close, close_len) == 0 &&
+          strncmp(&xx[i + close_len], close, close_len) == 0) {
+        i += close_len;
+      }
+
+      str[j++] = xx[i];
+      break;
+    }
+    case escape: {
+      state = prev_state;
+      break;
+    }
+    case single_quote: {
+      if (xx[i] == '\\') {
+        prev_state = single_quote;
+        state = escape;
+      } else if (xx[i] == '\'') {
+        state = delim;
+      }
+      break;
+    }
+    case double_quote: {
+      if (xx[i] == '\\') {
+        prev_state = double_quote;
+        state = escape;
+      } else if (xx[i] == '\"') {
+        state = delim;
+      }
+      break;
+    }
+    case backtick: {
+      if (xx[i] == '\\') {
+        prev_state = backtick;
+        state = escape;
+      } else if (xx[i] == '`') {
+        state = delim;
+      }
+      break;
+    }
+    case comment: {
+      if (xx[i] == '\n') {
+        state = delim;
+      }
+      break;
+    }
+    case delim: {
+      if (!delim_equal && strncmp(&xx[i], open, open_len) == 0) {
+        ++delim_level;
+        i += open_len - 1;
+      } else if (strncmp(&xx[i], close, close_len) == 0) {
+        --delim_level;
+        i += close_len - 1;
+      } else {
+        if (!literal && xx[i] == comment_char) {
+          state = comment;
+        } else {
+          switch (xx[i]) {
+          case '\'':
+            if (!literal) {
+              state = single_quote;
+            }
+            break;
+          case '"':
+            if (!literal) {
+              state = double_quote;
+            }
+            break;
+          case '`':
+            if (!literal) {
+              state = backtick;
+            }
+            break;
+          };
+        }
+      }
+      if (delim_level == 0) {
+        /* Result of the current glue statement */
+        SEXP expr = PROTECT(Rf_ScalarString(
+            Rf_mkCharLenCE(&xx[start], (i - close_len) + 1 - start, CE_UTF8)));
+        SEXP call = PROTECT(Rf_lang2(f, expr));
+        SEXP result = PROTECT(Rf_eval(call, R_EmptyEnv));
+
+        /* text in between last glue statement */
+        if (j > 0) {
+          str[j] = '\0';
+          SEXP str_ = PROTECT(Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+          REPROTECT(out = set(out, k++, str_), out_idx);
+          UNPROTECT(1);
+        }
+
+        REPROTECT(out = set(out, k++, result), out_idx);
+
+        /* Clear the string buffer */
+        memset(str, 0, j);
+        j = 0;
+        UNPROTECT(3);
+        state = text;
+      }
+      break;
+    }
+    };
+  }
+
+  if (k == 0 || j > 0) {
+    str[j] = '\0';
+    SEXP str_ = PROTECT(Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+    REPROTECT(out = set(out, k++, str_), out_idx);
+    UNPROTECT(1);
+  }
+
+  if (state == delim) {
+    free(str);
+    Rf_error("Expecting '%s'", close);
+  } else if (state == single_quote) {
+    free(str);
+    Rf_error("Unterminated quote (')");
+  } else if (state == double_quote) {
+    free(str);
+    Rf_error("Unterminated quote (\")");
+  } else if (state == backtick) {
+    free(str);
+    Rf_error("Unterminated quote (`)");
+  } else if (state == comment) {
+    free(str);
+    Rf_error("Unterminated comment");
+  }
+
+  free(str);
+
+  out = resize(out, k);
+
+  UNPROTECT(1);
+
+  return out;
+}

--- a/src/glue.c
+++ b/src/glue.c
@@ -22,7 +22,7 @@ SEXP resize(SEXP out, R_xlen_t n) {
   return Rf_xlengthgets(out, n);
 }
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg) {
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg) {
 
   typedef enum {
     text,
@@ -31,8 +31,7 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg) {
     double_quote,
     backtick,
     delim,
-    comment,
-    ignored_delim
+    comment
   } states;
 
   const char* xx = Rf_translateCharUTF8(STRING_ELT(x, 0));
@@ -48,8 +47,8 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg) {
 
   char comment_char = '\0';
 
-  int round = INTEGER(round_arg)[0];
-  Rboolean literal = 1;
+  Rboolean litorig = LOGICAL(lit_arg)[0];
+  Rboolean literal = litorig;
 
   int delim_equal = strncmp(open, close, open_len) == 0;
 
@@ -67,18 +66,16 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP round_arg) {
   for (i = 0; i < str_len; ++i) {
     switch (state) {
     case text: {
-      if (strncmp(&xx[i], open, open_len) == 0 &&
-          ((round == 1 && xx[i+1] != '.') ||
-           (round == 2 && xx[i+1] == '.') ||
-           (round == 3))) {
+      if (strncmp(&xx[i], open, open_len) == 0) {
         /* check for open delim doubled */
         if (strncmp(&xx[i + open_len], open, open_len) == 0) {
           i += open_len;
         } else {
-          // In round 1 we parse {} with literal = FALSE and {?} with
-          // literal = TRUE.
-          // In round 2 we parse {.} with literal = TRUE
-          literal = round == 2 || round == 3 || xx[i+1] == '?';
+          // If .literal was NA then We parse {. } and {? }
+          // expressions with literal = TRUE
+          if (litorig == NA_LOGICAL) {
+            literal = xx[i+1] == '.' || xx[i+1] == '?';
+          }
           state = delim;
           delim_level = 1;
           start = i + open_len;

--- a/src/glue.c
+++ b/src/glue.c
@@ -4,6 +4,7 @@
 #include "Rinternals.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 SEXP set(SEXP x, int i, SEXP val) {
   R_xlen_t len = Rf_xlength(x);
@@ -226,5 +227,127 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP cli_arg) {
 
   UNPROTECT(1);
 
+  return out;
+}
+
+SEXP trim_(SEXP x) {
+  size_t len = LENGTH(x);
+
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, len));
+  size_t num;
+  for (num = 0; num < len; ++num) {
+    const char* xx = Rf_translateCharUTF8(STRING_ELT(x, num));
+    size_t str_len = strlen(xx);
+
+    char* str = (char*)malloc(str_len + 1);
+    size_t i = 0, start = 0;
+    bool new_line = false;
+
+    /* skip leading blanks on first line */
+    while (start < str_len && (xx[start] == ' ' || xx[start] == '\t')) {
+      ++start;
+    }
+
+    /* Skip first newline */
+    if (start < str_len && xx[start] == '\n') {
+      new_line = true;
+      ++start;
+    }
+
+    i = start;
+
+    /* Ignore first line */
+    if (!new_line) {
+      while (i < str_len && xx[i] != '\n') {
+        ++i;
+      }
+      new_line = true;
+    }
+
+    size_t indent = 0;
+
+    /* Maximum size of size_t */
+    size_t min_indent = (size_t)-1;
+
+    /* find minimum indent */
+    while (i < str_len) {
+      if (xx[i] == '\n') {
+        new_line = true;
+        indent = 0;
+      } else if (new_line) {
+        if (xx[i] == ' ' || xx[i] == '\t') {
+          ++indent;
+        } else {
+          if (indent < min_indent) {
+            min_indent = indent;
+          }
+          indent = 0;
+          new_line = false;
+        }
+      }
+      ++i;
+    }
+
+    /* if string ends with '\n', `indent = 0` only because we made it so */
+    if (xx[str_len - 1] != '\n' && new_line && indent < min_indent) {
+      min_indent = indent;
+    }
+
+    new_line = true;
+    i = start;
+    size_t j = 0;
+
+    /*Rprintf("start: %i\nindent: %i\nmin_indent: %i", start, indent,
+     * min_indent);*/
+
+    /* copy the string removing the minimum indent from new lines */
+    while (i < str_len) {
+      if (xx[i] == '\n') {
+        new_line = true;
+      } else if (xx[i] == '\\' && i + 1 < str_len && xx[i + 1] == '\n') {
+        new_line = true;
+        i += 2;
+        continue;
+      } else if (new_line) {
+        size_t skipped = strspn(xx + i, "\t ");
+        /*
+         * if the line consists only of tabs and spaces, and if the line is
+         * shorter than min_indent, copy the entire line and proceed to the
+         * next
+         */
+        if (*(xx + i + skipped) == '\n' && skipped < min_indent) {
+          strncpy(str + j, xx + i, skipped);
+          i += skipped;
+          j += skipped;
+        } else {
+          if (i + min_indent < str_len && (xx[i] == ' ' || xx[i] == '\t')) {
+            i += min_indent;
+          }
+        }
+        new_line = false;
+        continue;
+      }
+      str[j++] = xx[i++];
+    }
+    str[j] = '\0';
+
+    /* Remove trailing whitespace up to the first newline */
+    size_t end = j;
+    while (j > 0) {
+      if (str[j] == '\n') {
+        end = j;
+        break;
+      } else if (str[j] == '\0' || str[j] == ' ' || str[j] == '\t') {
+        --j;
+      } else {
+        break;
+      }
+    }
+    str[end] = '\0';
+    SET_STRING_ELT(out, num, Rf_mkCharCE(str, CE_UTF8));
+    free(str);
+  }
+
+  UNPROTECT(1);
   return out;
 }

--- a/src/glue.c
+++ b/src/glue.c
@@ -22,7 +22,7 @@ SEXP resize(SEXP out, R_xlen_t n) {
   return Rf_xlengthgets(out, n);
 }
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg) {
 
   typedef enum {
     text,
@@ -47,7 +47,8 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
 
   char comment_char = '\0';
 
-  Rboolean literal = 1;
+  Rboolean litorig = LOGICAL(lit_arg)[0];
+  Rboolean literal = litorig;
 
   int delim_equal = strncmp(open, close, open_len) == 0;
 
@@ -70,6 +71,11 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
         if (strncmp(&xx[i + open_len], open, open_len) == 0) {
           i += open_len;
         } else {
+          // If .literal was NA then We parse {. } and {? }
+          // expressions with literal = TRUE
+          if (litorig == NA_LOGICAL) {
+            literal = xx[i+1] == '.' || xx[i+1] == '?';
+          }
           state = delim;
           delim_level = 1;
           start = i + open_len;

--- a/src/glue.c
+++ b/src/glue.c
@@ -22,7 +22,7 @@ SEXP resize(SEXP out, R_xlen_t n) {
   return Rf_xlengthgets(out, n);
 }
 
-SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg) {
+SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
 
   typedef enum {
     text,
@@ -47,8 +47,7 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg) {
 
   char comment_char = '\0';
 
-  Rboolean litorig = LOGICAL(lit_arg)[0];
-  Rboolean literal = litorig;
+  Rboolean literal = 1;
 
   int delim_equal = strncmp(open, close, open_len) == 0;
 
@@ -71,11 +70,6 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP lit_arg) {
         if (strncmp(&xx[i + open_len], open, open_len) == 0) {
           i += open_len;
         } else {
-          // If .literal was NA then We parse {. } and {? }
-          // expressions with literal = TRUE
-          if (litorig == NA_LOGICAL) {
-            literal = xx[i+1] == '.' || xx[i+1] == '?';
-          }
           state = delim;
           delim_level = 1;
           start = i + open_len;

--- a/src/init.c
+++ b/src/init.c
@@ -72,6 +72,8 @@ static const R_CallMethodDef callMethods[]  = {
   { "clic_get_embedded_utf8", (DL_FUNC) clic_get_embedded_utf8, 0 },
   { "clic_set_embedded_utf8", (DL_FUNC) clic_set_embedded_utf8, 1 },
 
+  { "glue_",               (DL_FUNC) glue_,               4 },
+
   { NULL, NULL, 0 }
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -72,7 +72,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "clic_get_embedded_utf8", (DL_FUNC) clic_get_embedded_utf8, 0 },
   { "clic_set_embedded_utf8", (DL_FUNC) clic_set_embedded_utf8, 1 },
 
-  { "glue_",               (DL_FUNC) glue_,               5 },
+  { "glue_",               (DL_FUNC) glue_,               4 },
 
   { NULL, NULL, 0 }
 };

--- a/src/init.c
+++ b/src/init.c
@@ -73,6 +73,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "clic_set_embedded_utf8", (DL_FUNC) clic_set_embedded_utf8, 1 },
 
   { "glue_",               (DL_FUNC) glue_,               5 },
+  { "trim_",               (DL_FUNC) trim_,               1 },
 
   { NULL, NULL, 0 }
 };

--- a/src/init.c
+++ b/src/init.c
@@ -72,7 +72,7 @@ static const R_CallMethodDef callMethods[]  = {
   { "clic_get_embedded_utf8", (DL_FUNC) clic_get_embedded_utf8, 0 },
   { "clic_set_embedded_utf8", (DL_FUNC) clic_set_embedded_utf8, 1 },
 
-  { "glue_",               (DL_FUNC) glue_,               4 },
+  { "glue_",               (DL_FUNC) glue_,               5 },
 
   { NULL, NULL, 0 }
 };

--- a/tests/testthat/_snaps/glue.md
+++ b/tests/testthat/_snaps/glue.md
@@ -37,3 +37,10 @@
     Message
       <URL> 2 2
 
+# { } is parsed with literal = FALSE
+
+    Code
+      format_message("{.emph {'{foo {}'}}")
+    Output
+      [1] "{foo {}"
+

--- a/tests/testthat/_snaps/glue.md
+++ b/tests/testthat/_snaps/glue.md
@@ -6,32 +6,12 @@
       test_1: all good
       test_2: not #good
     Code
-      cli::cli_dl(c(test_3 = "no' good either"))
-    Message <cliMessage>
-      test_3: no' good either
-    Code
-      cli::cli_dl(c(test_4 = "no\" good also"))
-    Message <cliMessage>
-      test_4: no" good also
-    Code
       cli::cli_text("{.url https://example.com/#section}")
     Message
       <https://example.com/#section>
-    Code
-      cli::cli_alert_success("Qapla'")
-    Message <cliMessage>
-      v Qapla'
 
 # quotes, etc. within expressions are still OK
 
-    Code
-      cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
-    Message <cliMessage>
-      <URL> 3
-    Code
-      cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
-    Message <cliMessage>
-      <URL> 3
     Code
       cli::cli_text("{.url URL} {1 + 1 # + 1} {1 + 1}")
     Message

--- a/tests/testthat/_snaps/glue.md
+++ b/tests/testthat/_snaps/glue.md
@@ -6,12 +6,32 @@
       test_1: all good
       test_2: not #good
     Code
+      cli::cli_dl(c(test_3 = "no' good either"))
+    Message <cliMessage>
+      test_3: no' good either
+    Code
+      cli::cli_dl(c(test_4 = "no\" good also"))
+    Message <cliMessage>
+      test_4: no" good also
+    Code
       cli::cli_text("{.url https://example.com/#section}")
     Message
       <https://example.com/#section>
+    Code
+      cli::cli_alert_success("Qapla'")
+    Message <cliMessage>
+      v Qapla'
 
 # quotes, etc. within expressions are still OK
 
+    Code
+      cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
+    Message <cliMessage>
+      <URL> 3
+    Code
+      cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
+    Message <cliMessage>
+      <URL> 3
     Code
       cli::cli_text("{.url URL} {1 + 1 # + 1} {1 + 1}")
     Message

--- a/tests/testthat/_snaps/glue.md
+++ b/tests/testthat/_snaps/glue.md
@@ -6,12 +6,32 @@
       test_1: all good
       test_2: not #good
     Code
+      cli::cli_dl(c(test_3 = "no' good either"))
+    Message
+      test_3: no' good either
+    Code
+      cli::cli_dl(c(test_4 = "no\" good also"))
+    Message
+      test_4: no" good also
+    Code
       cli::cli_text("{.url https://example.com/#section}")
     Message
       <https://example.com/#section>
+    Code
+      cli::cli_alert_success("Qapla'")
+    Message
+      v Qapla'
 
 # quotes, etc. within expressions are still OK
 
+    Code
+      cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
+    Message
+      <URL> 3
+    Code
+      cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
+    Message
+      <URL> 3
     Code
       cli::cli_text("{.url URL} {1 + 1 # + 1} {1 + 1}")
     Message

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -31,3 +31,10 @@ test_that("{. } is always a style", {
   vals <- glue_cmd("{.foo }", .envir = environment())$values
   expect_false(any(grepl("^v[0-9]+$", names(vals))))
 })
+
+test_that("We can use doubling to escape { and }", {
+  txt <- "{.emph {'{{foo {{}}'}}"
+  expect_snapshot(
+    format_message(txt)
+  )
+})

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -32,9 +32,8 @@ test_that("{. } is always a style", {
   expect_false(any(grepl("^v[0-9]+$", names(vals))))
 })
 
-test_that("We can use doubling to escape { and }", {
-  txt <- "{.emph {'{{foo {{}}'}}"
+test_that("{ } is parsed with literal = FALSE", {
   expect_snapshot(
-    format_message(txt)
+    format_message("{.emph {'{foo {}'}}")
   )
 })

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -9,17 +9,17 @@ test_that("glue quotes and comments", {
         "test_2" = "not #good"
       )
     )
-#    cli::cli_dl(c("test_3" = "no' good either"))
-#    cli::cli_dl(c("test_4" = "no\" good also"))
+    cli::cli_dl(c("test_3" = "no' good either"))
+    cli::cli_dl(c("test_4" = "no\" good also"))
     cli::cli_text("{.url https://example.com/#section}")
-#    cli::cli_alert_success("Qapla'")
+    cli::cli_alert_success("Qapla'")
   })
 })
 
 test_that("quotes, etc. within expressions are still OK", {
   expect_snapshot({
-#    cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
-#    cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
+    cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
+    cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
     cli::cli_text("{.url URL} {1 + 1 # + 1} {1 + 1}")
   })
 })

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -9,17 +9,17 @@ test_that("glue quotes and comments", {
         "test_2" = "not #good"
       )
     )
-    cli::cli_dl(c("test_3" = "no' good either"))
-    cli::cli_dl(c("test_4" = "no\" good also"))
+#    cli::cli_dl(c("test_3" = "no' good either"))
+#    cli::cli_dl(c("test_4" = "no\" good also"))
     cli::cli_text("{.url https://example.com/#section}")
-    cli::cli_alert_success("Qapla'")
+#    cli::cli_alert_success("Qapla'")
   })
 })
 
 test_that("quotes, etc. within expressions are still OK", {
   expect_snapshot({
-    cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
-    cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
+#    cli::cli_text("{.url URL} {x <- 'foo'; nchar(x)}")
+#    cli::cli_text("{.url URL} {x <- \"foo\"; nchar(x)}")
     cli::cli_text("{.url URL} {1 + 1 # + 1} {1 + 1}")
   })
 })

--- a/tools/docs/glue.Rmd
+++ b/tools/docs/glue.Rmd
@@ -1,0 +1,84 @@
+---
+title: "About glue in cli"
+author: "Gábor Csárdi"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+editor_options:
+  markdown:
+    wrap: sentence
+---
+
+## Motivation
+
+-   It is difficult to do the two (or more) rounds of glue parsing currently, and we have some issues that are hard to fix, e.g. <https://github.com/r-lib/cli/issues/370> The main problem is that glue expects that the expression in delimiters is a valid R expressions, whereas in cli it can be any text.
+
+-   It would be simpler to have our own parser, which is essentially equivalent to glue for the real `{ ... }` expressions, but different for `{. ... }` and `{? ... }`.
+
+-   Then we could parse out the `{. ... }` and `{? ... }` expressions up front, with ease, instead of having to parse with glue with the regular `{` and `}` delimiters, and then try to special case the styles in a transformer.
+
+## Current use
+
+These are the glue calls in cli currently:
+
+``` r
+# inline.R
+glue::glue_collapse(as.character(x), sep = sep, last = last)
+
+out <- glue::glue(
+  text,
+  .envir = envir,
+  .transformer = inline_transformer,
+  .open = paste0("{", envir$marker),
+  .close = paste0(envir$marker, "}"),
+  .trim = TRUE,
+  .comment = ""
+)
+
+glue::glue(
+  t$str,
+  .envir = t$values,
+  .transformer = inline_transformer,
+  .open = paste0("{", t$values$marker),
+  .close = paste0(t$values$marker, "}"),
+  .trim = TRUE,
+  .comment = ""
+)
+
+out <- glue::glue(
+  text,
+  .envir = envir,
+  .transformer = sys.function(),
+  .trim = TRUE,
+  .comment = ""
+)
+
+pstr <- glue::glue(
+  str,
+  .envir = .envir,
+  .transformer = transformer,
+  .trim = TRUE,
+  .comment = ""
+)
+
+# pluralize.R
+raw <- glue::glue(..., .envir = .envir, .transformer = tf, .comment = "")
+
+# ansi-hyperlink.R
+params <- glue::glue_collapse(sep = ":",
+  glue::glue("{names(params)}={params}")
+)
+```
+
+The `ansi-hyperlink.R` usage does not matter, that can be replaced by base R code easily, but we can also keep it as long as we depend on glue.
+
+We can keep the calls to `glue::glue()` in `pluralize.R` and also the `glue_collapse()` call.
+We can rewrite these later, if we want to avoid depending on glue.
+
+## Ideas
+
+First try to do this with glue, and parse `{. ... }` and `{? ... }` expressions with `.literal = TRUE` and replace them with special delimiters.
+Ideally we would allow doubling the braces here for escaping, but glue currently does not allow that (<https://github.com/tidyverse/glue/issues/259>).
+Then we parse with `{ ... }` and save the evaluated values.
+
+The other option is writing our own parser.


### PR DESCRIPTION
Correct glue parsing. I.e. `{}` is parsed with `literal = FALSE` and `{.}` is parsed with `literal = TRUE`.