### PR TITLE
Set empty param-lists to `void` in exported `progress.h` file

### DIFF
--- a/inst/include/cli/progress.h
+++ b/inst/include/cli/progress.h
@@ -105,7 +105,7 @@ static R_INLINE void cli_progress_done(SEXP bar);
 //'
 //' Initialize the cli timer without creating a progress bar.
 
-static R_INLINE void cli_progress_init_timer();
+static R_INLINE void cli_progress_init_timer(void);
 
 //' ### `cli_progress_num()`
 //'
@@ -115,7 +115,7 @@ static R_INLINE void cli_progress_init_timer();
 //'
 //' Returns the number of currently active progress bars.
 
-static R_INLINE int cli_progress_num();
+static R_INLINE int cli_progress_num(void);
 
 //' ### `cli_progress_set()`
 //'
@@ -380,9 +380,9 @@ static R_INLINE void cli_progress_add(SEXP bar, double inc) {
 }
 
 static R_INLINE int cli_progress_num() {
-  static int (*ptr)() = NULL;
+  static int (*ptr)(void) = NULL;
   if (ptr == NULL) {
-    ptr = (int (*)()) R_GetCCallable("cli", "cli_progress_num");
+    ptr = (int (*)(void)) R_GetCCallable("cli", "cli_progress_num");
   }
   return ptr();
 }

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,1 @@
-PKG_CFLAGS = $(C_VISIBILITY)
+PKG_CFLAGS = $(C_VISIBILITY) -I../inst/include

--- a/src/inst.c
+++ b/src/inst.c
@@ -1,0 +1,9 @@
+#include <Rinternals.h>
+#include <cli/progress.h>
+
+// This file only tests that `inst/cli/progress.h` can be compiled
+// without issues
+
+void test(void) {
+  cli_progress_bar(0, R_NilValue);
+}


### PR DESCRIPTION
I added a dummy .c file that includes the exported header so that we can detect issues when building cli itself.