### PR TITLE
format_inline() now keeps newline characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
   unconditionally, as before.) See the the `cli.progress_show_after`
   option in `?cli-config` for details (#542).
 
+* `format_inline()` now has a new argument `keep_newlines`, and it keeps
+  newline characters by default.
+
 # cli 3.5.0
 
 * New `keypress()` function to read a single key press from a terminal.

--- a/R/cli.R
+++ b/R/cli.R
@@ -102,15 +102,20 @@ cli_fmt <- function(expr, collapse = FALSE, strip_newline = FALSE) {
 #' @param .envir Environment to evaluate the expressions in.
 #' @param collapse Whether to collapse the result if it has multiple
 #'   lines, e.g. because of `\f` characters.
+#' @param keep_newlines Whether to keep newlines in the result, or treat
+#'   them as regular space characters.
 #' @return Character scalar, the formatted string.
 #'
 #' @export
 #' @examples
 #' format_inline("A message for {.emph later}, thanks {.fn format_inline}.")
 
-format_inline <- function(..., .envir = parent.frame(), collapse = TRUE) {
+format_inline <- function(..., .envir = parent.frame(), collapse = TRUE,
+                          keep_newlines = TRUE) {
   str <- paste0(unlist(list(...), use.names = FALSE), collapse = "")
-  str <- gsub("\n", "\f", str, fixed = TRUE)
+  if (keep_newlines) {
+    str <- gsub("\n", "\f", str, fixed = TRUE)
+  }
   opts <- options(cli.width = Inf)
   on.exit(options(opts), add = TRUE)
   cli_fmt(

--- a/R/cli.R
+++ b/R/cli.R
@@ -109,10 +109,12 @@ cli_fmt <- function(expr, collapse = FALSE, strip_newline = FALSE) {
 #' format_inline("A message for {.emph later}, thanks {.fn format_inline}.")
 
 format_inline <- function(..., .envir = parent.frame(), collapse = TRUE) {
+  str <- paste0(unlist(list(...), use.names = FALSE), collapse = "")
+  str <- gsub("\n", "\f", str, fixed = TRUE)
   opts <- options(cli.width = Inf)
   on.exit(options(opts), add = TRUE)
   cli_fmt(
-    cli_text(..., .envir = .envir),
+    cli_text(str, .envir = .envir),
     collapse = collapse,
     strip_newline = TRUE
   )

--- a/man/format_inline.Rd
+++ b/man/format_inline.Rd
@@ -4,7 +4,12 @@
 \alias{format_inline}
 \title{Format and returns a line of text}
 \usage{
-format_inline(..., .envir = parent.frame(), collapse = TRUE)
+format_inline(
+  ...,
+  .envir = parent.frame(),
+  collapse = TRUE,
+  keep_newlines = TRUE
+)
 }
 \arguments{
 \item{...}{Passed to \code{\link[=cli_text]{cli_text()}}.}
@@ -13,6 +18,9 @@ format_inline(..., .envir = parent.frame(), collapse = TRUE)
 
 \item{collapse}{Whether to collapse the result if it has multiple
 lines, e.g. because of \verb{\\f} characters.}
+
+\item{keep_newlines}{Whether to keep newlines in the result, or treat
+them as regular space characters.}
 }
 \value{
 Character scalar, the formatted string.

--- a/tests/testthat/_snaps/inline-2.md
+++ b/tests/testthat/_snaps/inline-2.md
@@ -398,3 +398,41 @@
       Caused by error:
       ! non-numeric argument to binary operator
 
+# format_inline and newlines
+
+    Code
+      format_inline("foo\nbar", keep_newlines = TRUE)
+    Output
+      [1] "foo\nbar"
+    Code
+      format_inline("\nfoo\n\nbar\n", keep_newlines = TRUE)
+    Output
+      [1] "\nfoo\n\nbar\n"
+    Code
+      format_inline("foo\fbar", keep_newlines = TRUE)
+    Output
+      [1] "foo\nbar"
+    Code
+      format_inline("\ffoo\f\fbar\f", keep_newlines = TRUE)
+    Output
+      [1] "\nfoo\n\nbar\n"
+
+---
+
+    Code
+      format_inline("foo\nbar", keep_newlines = FALSE)
+    Output
+      [1] "foo bar"
+    Code
+      format_inline("\nfoo\n\nbar\n", keep_newlines = FALSE)
+    Output
+      [1] "foo\n\nbar"
+    Code
+      format_inline("foo\fbar", keep_newlines = FALSE)
+    Output
+      [1] "foo\nbar"
+    Code
+      format_inline("\ffoo\f\fbar\f", keep_newlines = FALSE)
+    Output
+      [1] "\nfoo\n\nbar\n"
+

--- a/tests/testthat/test-inline-2.R
+++ b/tests/testthat/test-inline-2.R
@@ -181,3 +181,18 @@ test_that("various errors", {
     transform = function(x) sanitize_call(sanitize_srcref(x))
   )
 })
+
+test_that("format_inline and newlines", {
+  expect_snapshot({
+    format_inline("foo\nbar", keep_newlines = TRUE)
+    format_inline("\nfoo\n\nbar\n", keep_newlines = TRUE)
+    format_inline("foo\fbar", keep_newlines = TRUE)
+    format_inline("\ffoo\f\fbar\f", keep_newlines = TRUE)
+  })
+  expect_snapshot({
+    format_inline("foo\nbar", keep_newlines = FALSE)
+    format_inline("\nfoo\n\nbar\n", keep_newlines = FALSE)
+    format_inline("foo\fbar", keep_newlines = FALSE)
+    format_inline("\ffoo\f\fbar\f", keep_newlines = FALSE)
+  })
+})


### PR DESCRIPTION
It does not break any tests, but we might need to change the
default to `FALSE` if it breaks reverse dependencies.