### PR TITLE
Add param `sep2`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,8 @@ Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre")),
     person("Hadley", "Wickham", role = "ctb"),
     person("Kirill", "Müller", role = "ctb"),
+    person("Salim", "Brüggemann", , "salim-b@pm.me", role = "ctb",
+           comment = c(ORCID = "0000-0002-5329-5987")),
     person("RStudio", role = c("cph", "fnd"))
   )
 Description: A suite of tools to build attractive command line interfaces

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@
 * `ansi_collapse(x, trunc = 1, style = "head")` now indeed show one element
   if `length(x) == 2`, as documented (@salim-b, #572).
 
+* `ansi_collapse()` gains a `sep2` argument to specify a seperate separator
+  for length-two inputs. It defaults to `" and "` which, in conjunction with
+  the other defaults, produces a collapsed string that fully adheres to the
+  [serial comma](https://en.wikipedia.org/wiki/Serial_comma) rules.
+
 * `ansi_string()` is now an exported function (@multimeric, #573).
 
 # cli 3.6.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
   for length-two inputs. It defaults to `" and "` which, in conjunction with
   the other defaults, produces a collapsed string that fully adheres to the
   [serial comma](https://en.wikipedia.org/wiki/Serial_comma) rules.
+  (@salim-b, #569)
 
 * `ansi_string()` is now an exported function (@multimeric, #573).
 

--- a/R/inline.R
+++ b/R/inline.R
@@ -44,18 +44,16 @@ inline_generic <- function(app, x, style) {
 
 inline_collapse <- function(x, style = list()) {
   sep <- style[["vec-sep"]] %||% style[["vec_sep"]] %||% ", "
-  if (length(x) >= 3) {
-    last <- style[["vec-last"]] %||% style[["vec_last"]] %||% ", and "
-  } else {
-    last <- style[["vec-sep2"]] %||% style[["vec_sep2"]] %||% style[["vec-last"]] %||%
-      style[["vec_last"]] %||% " and "
-  }
+  sep2 <- style[["vec-sep2"]] %||% style[["vec_sep2"]] %||% " and "
+  last <- style[["vec-last"]] %||% style[["vec_last"]] %||% ", and "
+
   trunc <- style[["vec-trunc"]] %||% style[["vec_trunc"]] %||% 20L
   col_style <- style[["vec-trunc-style"]] %||% "both-ends"
 
   ansi_collapse(
     x,
     sep = sep,
+    sep2 = sep2,
     last = last,
     trunc = trunc,
     style = col_style

--- a/man/ansi_collapse.Rd
+++ b/man/ansi_collapse.Rd
@@ -7,6 +7,7 @@
 ansi_collapse(
   x,
   sep = ", ",
+  sep2 = " and ",
   last = ", and ",
   trunc = Inf,
   width = Inf,
@@ -18,10 +19,13 @@ ansi_collapse(
 \item{x}{Character vector, or an object with an \code{as.character()} method
 to collapse.}
 
-\item{sep}{Character string, separator.}
+\item{sep}{Separator. A character string.}
+
+\item{sep2}{Separator for the special case that \code{x} contains only two
+elements. A character string.}
 
 \item{last}{Last separator, if there is no truncation. E.g. use
-\code{", and "} for the Oxford comma.}
+\code{", and "} for the \href{https://en.wikipedia.org/wiki/Serial_comma}{serial comma}. A character string.}
 
 \item{trunc}{Maximum number of elements to show. For \code{style = "head"}
 at least \code{trunc = 1} is used. For \code{style = "both-ends"} at least
@@ -45,14 +49,15 @@ end, if needed.
 }}
 }
 \value{
-Character scalar. It is \code{NA_character_} if any elements in the
-vector are \code{NA}.
+Character scalar. It is \code{NA_character_} if any elements in \code{x}
+are \code{NA}.
 }
 \description{
 Features:
 \itemize{
-\item custom separator,
-\item custom last separator: \code{last} argument,
+\item custom separator (\code{sep}),
+\item custom separator for length-two input (\code{sep2}),
+\item custom last separator (\code{last}),
 \item adds ellipsis to truncated strings,
 \item uses Unicode ellipsis character on UTF-8 console,
 \item can collapse "from both ends", with \code{style = "both-ends"},
@@ -70,5 +75,5 @@ ansi_collapse(letters, trunc = 5)
 ansi_collapse(letters, trunc = 5, style = "head")
 }
 \seealso{
-\code{glue_collapse} in the glue package inspired this function
+\code{glue_collapse} in the glue package inspired this function.
 }

--- a/tests/testthat/_snaps/collapsing.md
+++ b/tests/testthat/_snaps/collapsing.md
@@ -81,7 +81,7 @@
     Code
       cli_text("{v(2,1)}")
     Message
-      1, ...
+      1 and 2
     Code
       cli_text("{v(3,1)}")
     Message

--- a/tests/testthat/test-collapsing.R
+++ b/tests/testthat/test-collapsing.R
@@ -186,11 +186,6 @@ test_that("ansi_collapse with width trimming", {
   })
 })
 
-test_that("ansi_collapse produces consistent truncation results", {
-  expect_equal(ansi_collapse(1:2, trunc = 1, style = "head"),
-               ansi_collapse(1:2, trunc = 0, style = "head"))
-})
-
 test_that("ansi_collapse uses `sep2` for length-two inputs", {
   expect_equal(ansi_collapse(1:2),
                "1 and 2")

--- a/tests/testthat/test-collapsing.R
+++ b/tests/testthat/test-collapsing.R
@@ -186,6 +186,11 @@ test_that("ansi_collapse with width trimming", {
   })
 })
 
+test_that("ansi_collapse produces consistent truncation results", {
+  expect_equal(ansi_collapse(1:2, trunc = 1, style = "head"),
+               ansi_collapse(1:2, trunc = 0, style = "head"))
+})
+
 test_that("ansi_collapse uses `sep2` for length-two inputs", {
   expect_equal(ansi_collapse(1:2),
                "1 and 2")

--- a/tests/testthat/test-collapsing.R
+++ b/tests/testthat/test-collapsing.R
@@ -190,3 +190,10 @@ test_that("ansi_collapse produces consistent truncation results", {
   expect_equal(ansi_collapse(1:2, trunc = 1, style = "head"),
                ansi_collapse(1:2, trunc = 0, style = "head"))
 })
+
+test_that("ansi_collapse uses `sep2` for length-two inputs", {
+  expect_equal(ansi_collapse(1:2),
+               "1 and 2")
+  expect_equal(ansi_collapse(1:2, trunc = 2, style = "head"),
+               "1 and 2")
+})


### PR DESCRIPTION
Fixes #568.

Some snapshot tests failed (i.e. produced different output). I think most of them currently also fail on the `main` branch, i.e. have nothing to do with this PR. ~~But I noticed one particular test that might actually be caused by this PR:~~

~~I'm not familiar enough with cli to understand why that is, so I'll leave it to you. Hope that's fine. 🙂~~ *I've updated `inline_collapse()` which relies on `ansi_collapse()`. Should be fine now.*