### PR TITLE
Document `str` in the class list

### DIFF
--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -80,7 +80,7 @@
 #' * `run` is an R expression, that is potentially clickable if the terminal
 #'   supports ANSI hyperlinks to runnable code (e.g. RStudio).
 #'   It supports link text. See [links] for more about cli hyperlinks.
-#' * `str` for a double quoted string.
+#' * `str` for a double quoted string escaped by [base::encodeString()].
 #' * `strong` for strong importance.
 #' * `topic` is a help page of a _ropic_.
 #'   If the terminal supports ANSI hyperlinks to help pages (e.g. RStudio),

--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -80,6 +80,7 @@
 #' * `run` is an R expression, that is potentially clickable if the terminal
 #'   supports ANSI hyperlinks to runnable code (e.g. RStudio).
 #'   It supports link text. See [links] for more about cli hyperlinks.
+#' * `str` for a double quoted string.
 #' * `strong` for strong importance.
 #' * `topic` is a help page of a _ropic_.
 #'   If the terminal supports ANSI hyperlinks to help pages (e.g. RStudio),


### PR DESCRIPTION
Looks like https://github.com/r-lib/cli/commit/1afdf2ff235c8c8e44d3a744ed0651fad83390c3 partially documented it, but I can't ever remember a class name unless it is in the bulleted list

I can't seem to re-document cli, it gives me:

```r
==> devtools::document(roclets = c('rd', 'collate', 'namespace'))

ℹ Updating cli documentation
Setting `RoxygenNote` to "7.2.3"
ℹ Loading cli
Warning: [cliapp-docs.R:178] @section has mismatched braces or quotes
Warning: [cliapp-docs.R:417] @description has mismatched braces or quotes
Error in collapse(c(x$value$title, y$value$title), c(x$value$content,  : 
  length(key) == length(value) is not TRUE
Calls: suppressPackageStartupMessages ... merge -> merge.rd_section_section -> collapse -> stopifnot
In addition: Warning message:
Failed to source `man/roxygen/meta.R` 
Execution halted

Exited with status 1.
```