### PR TITLE
Fix GitHub link in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: A suite of tools to build attractive command line interfaces
     and 'Unicode' symbols with 'ASCII' alternatives. It support ANSI
     colors and text styles as well.
 License: MIT + file LICENSE
-URL: https://cli.r-lib.org, https://github.com/r-lib/cli#readme
+URL: https://cli.r-lib.org, https://github.com/r-lib/cli
 BugReports: https://github.com/r-lib/cli/issues
 Depends: 
     R (>= 3.4)


### PR DESCRIPTION
Since cli now has a pkgdown website, we no longer need to be directed to the README.
Remove #readme tag in URL