### PR TITLE
Typo fixes and clarification to hash.R docs

### DIFF
--- a/R/hash.R
+++ b/R/hash.R
@@ -194,7 +194,7 @@ hash_obj_md5 <- function(x, serialize_version = 2) {
 #' @export
 #' @rdname hash_md5
 #' @param paths Character vector of file names.
-#' @details `hash_file_md5()` calcultaes the MD5 hash of one of more
+#' @details `hash_file_md5()` calculates the MD5 hash of one or more
 #' files.
 
 hash_file_md5 <- function(paths) {

--- a/R/hash.R
+++ b/R/hash.R
@@ -6,7 +6,7 @@
 #' @param x Character vector. If not a character vector, then
 #' [as.character()] is used to try to coerce it into one. `NA` entries
 #' will have an `NA` hash.
-#' @return `hash_sha256()` returns aharacter vector of hexadecimal
+#' @return `hash_sha256()` returns a character vector of hexadecimal
 #' SHA-256 hashes.
 
 #' @family hash functions

--- a/R/hash.R
+++ b/R/hash.R
@@ -378,7 +378,7 @@ hash_obj_emoji <- function(x, size = 3, serialize_version = 2) {
 #' }
 #' ```
 #'
-#' `hash_animals()` uses `r length(gfycat_animals)` animal names and
+#' `hash_animal()` uses `r length(gfycat_animals)` animal names and
 #' `r length(gfycat_adjectives)` different adjectives. The number of
 #' different hashes you can get for different values of `n_adj`:
 #'

--- a/R/hash.R
+++ b/R/hash.R
@@ -76,7 +76,7 @@ hash_file_sha256 <- function(paths) {
 #' @param x Character vector. If not a character vector, then
 #' [as.character()] is used to try to coerce it into one. `NA` entries
 #' will have an `NA` hash.
-#' @return `hash_sha1()` returns aharacter vector of hexadecimal
+#' @return `hash_sha1()` returns a character vector of hexadecimal
 #' SHA-1 hashes.
 
 #' @family hash functions

--- a/R/hash.R
+++ b/R/hash.R
@@ -236,7 +236,7 @@ hash_file_md5 <- function(paths) {
 #'
 #' @param x Character vector. `NA` entries will have an `NA` hash.
 #' @param size Number of emojis to use in a hash. Currently it has to
-#'   be between 1 and 4.
+#'   be from 1 through 4.
 #' @return `hash_emoji()` returns a data frame with columns
 #'   * `hash`: the emoji hash, a string of the requested size.
 #'   * `emojis`: list column with the emoji characters in character
@@ -397,7 +397,7 @@ hash_obj_emoji <- function(x, size = 3, serialize_version = 2) {
 #' from <https://gfycat.com>.
 #'
 #' @param x Character vector. `NA` entries will have an `NA` hash.
-#' @param n_adj Number of adjectives to use. It must be between 0 and 3.
+#' @param n_adj Number of adjectives to use. It must be from 0 through 3.
 #' @return A data frame with columns
 #'   * `hash`: the hash value, a string.
 #'   * `words`: list column with the adjectives and the animal name in a

--- a/R/hash.R
+++ b/R/hash.R
@@ -468,7 +468,7 @@ hash_animal1_transform <- function(md5, n_adj) {
 
 #' @export
 #' @rdname hash_animal
-#' @details `hash_raw_anima()` calculates the adjective-animal hash of
+#' @details `hash_raw_animal()` calculates the adjective-animal hash of
 #' the bytes of a raw vector.
 #'
 #' @return `hash_raw_animal()` and `hash_obj_animal()` return a list


### PR DESCRIPTION
Found and fixed a few typos in the docs in `hash.R` - very minor stuff.

Also proposing a change to how ranges are described to be less ambiguous about if they are inclusive - "from 1 through 4" instead of "between 1 and 4". The latter can be confusing and may mean 2 or 3 to some readers. 