### PR TITLE
Add missing c() in cli_abort() in vignettes/usethis-ui.Rmd

### DIFF
--- a/vignettes/usethis-ui.Rmd
+++ b/vignettes/usethis-ui.Rmd
@@ -291,10 +291,10 @@ ui_stop("Could not copy {ui_path(img)} to  {ui_path(logo_path)}, file already ex
 `cli_abort()` does the same and is formatted using `cli_bullets()`.
 
 ```{asciicast}
-cli_abort(
+cli_abort(c(
   "Could not copy {.file {img}} to {.file {logo_path}}, file already exists",
   "i" = "You can set {.arg overwrite = TRUE} to avoid this error"
-  )
+  ))
 ```
 
 ## `usethis::ui_todo()`
@@ -360,10 +360,10 @@ ui_warn("Could not copy {ui_path(img)} to  {ui_path(logo_path)}, file already ex
 `cli_warn()` does the same and is formatted using `cli_bullets()`.
 
 ```{asciicast}
-cli_warn(
+cli_warn(c(
   "Could not copy {.file {img}} to {.file {logo_path}}, file already exists",
   "i" = "You can set {.arg overwrite = TRUE} to avoid this warning"
-  )
+  ))
 ```
 
 ## `usethis::ui_yeah()`


### PR DESCRIPTION
missing `c()` in `cli_abort()` in [vignettes/usethis-ui.Rmd](https://github.com/r-lib/cli/blob/HEAD/vignettes/usethis-ui.Rmd)

The current document:
![image](https://github.com/r-lib/cli/assets/98389771/6544f3a0-7a36-4b76-8870-5a2041d767de)

after updates, it will be:
![image](https://github.com/r-lib/cli/assets/98389771/a311f705-068f-4cf7-a2b0-571753fedeac)

