### PR TITLE
Change semantics of cli.default_num_colors option

### DIFF
--- a/R/num-ansi-colors.R
+++ b/R/num-ansi-colors.R
@@ -106,6 +106,11 @@ num_ansi_colors <- function(stream = "auto") {
   # the `stderr()` stream, so we need to catch this case.
   if (is_stderr && sink.number("message") != 2) return(1L)
 
+  #' 1. If the `cli.default_num_colors` option is set, then we use that.
+
+  dopt <- get_default_number_of_colors()
+  if (!is.null(dopt)) return(as.integer(dopt))
+
   #' 1. If R is running inside RGui on Windows, or R.app on macOS, then we
   #'    return 1L.
 

--- a/man/cli-config.Rd
+++ b/man/cli-config.Rd
@@ -88,9 +88,25 @@ See \url{https://cli.r-lib.org/articles/semantic-cli.html#cli-messages-1}
 
 \subsection{\code{cli.default_num_colors}}{
 
-Default number of ANSI colors. This value is only used if ANSI color support
-is detected. You can set this value to keep relying on auto-detection,
-but to adjust the number of colors when cli detects color support.
+Default number of ANSI colors. This value is used if the number of colors
+is not already set by
+\itemize{
+\item the \code{cli.num_colors} option,
+\item the \verb{R_CLI_NU<_COLORS} environment variable,
+\item the \code{crayon.enabled} and \code{crayon.colors} options,
+\item the \code{NO_COLOR} environment variable,
+\item the \code{knitr.in.progress} option,
+\item a \code{sink()} call for the stream.
+}
+
+You can also use this option if color support is detected correctly, but
+you want to adjust the number of colors. E.g.
+\itemize{
+\item if \code{crayon.enabled} is \code{TRUE}, but \code{crayon.colors} is not,
+\item in Emacs on Windows,
+\item in terminals.
+}
+
 See \code{\link[=num_ansi_colors]{num_ansi_colors()}}. See also the \code{cli.num_colors} option.
 }
 

--- a/man/num_ansi_colors.Rd
+++ b/man/num_ansi_colors.Rd
@@ -62,6 +62,7 @@ be actually used, but there is no easy way to tell that.)
 active sink for it, then 1L is returned.
 (If a sink is active for "output", then R changes the \code{stdout()}
 stream, so this check is not needed.)
+\item If the \code{cli.default_num_colors} option is set, then we use that.
 \item If R is running inside RGui on Windows, or R.app on macOS, then we
 return 1L.
 \item If R is running inside RStudio, with color support, then the

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -79,9 +79,21 @@ See <https://cli.r-lib.org/articles/semantic-cli.html#cli-messages-1>
 
 ### `cli.default_num_colors`
 
-Default number of ANSI colors. This value is only used if ANSI color support
-is detected. You can set this value to keep relying on auto-detection,
-but to adjust the number of colors when cli detects color support.
+Default number of ANSI colors. This value is used if the number of colors
+is not already set by
+* the `cli.num_colors` option,
+* the `R_CLI_NU<_COLORS` environment variable,
+* the `crayon.enabled` and `crayon.colors` options,
+* the `NO_COLOR` environment variable,
+* the `knitr.in.progress` option,
+* a `sink()` call for the stream.
+
+You can also use this option if color support is detected correctly, but
+you want to adjust the number of colors. E.g.
+* if `crayon.enabled` is `TRUE`, but `crayon.colors` is not,
+* in Emacs on Windows,
+* in terminals.
+
 See [num_ansi_colors()]. See also the `cli.num_colors` option.
 
 ### `cli.dynamic`


### PR DESCRIPTION
So that it is possible to use it even if color support is not detected, but at least it is not ruled out by some other options and detections.