### PR TITLE
Fix -Wstrict-prototypes warning

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -12,7 +12,7 @@
 
 #ifdef _WIN32
 
-SEXP clic_getppid() {
+SEXP clic_getppid(void) {
   DWORD pid = GetCurrentProcessId();
   HANDLE handle = NULL;
   PROCESSENTRY32W pe = { 0 };


### PR DESCRIPTION
Seen in CRAN checks for Windows:
https://cran.r-project.org/web/checks/check_results_cli.html