### PR TITLE
Add inline text formatting example for function argument

### DIFF
--- a/vignettes/semantic-cli.Rmd
+++ b/vignettes/semantic-cli.Rmd
@@ -159,6 +159,7 @@ fun <- function() {
   cli_li("{.strong Strong} importance")
   cli_li("A piece of code: {.code sum(a) / length(a)}")
   cli_li("A package name: {.pkg cli}")
+  cli_li("An argument name: {.arg x}")
   cli_li("A function name: {.fn cli_text}")
   cli_li("A keyboard key: press {.kbd ENTER}")
   cli_li("A file name: {.file /usr/bin/env}")


### PR DESCRIPTION
I was looking through the semantic CLI vignette to find guidance on what inline text formatting to use for a **function argument/parameter**. I noticed in [vroom](https://github.com/tidyverse/vroom/blob/788df43997c0cee87588cc6c2bafd12784f51b83/R/path.R#L41-L47) that `{arg file}` is used. This PR adds argument styling as an example to the vignette.