### PR TITLE
Fix build on clang/arm64

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,2 @@
 PKG_CFLAGS = $(C_VISIBILITY) -I../inst/include
+PKG_LIBS = -lpthread


### PR DESCRIPTION
Right now we see:

```
...
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c progress-altrep.c -o progress-altrep.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c progress.c -o progress.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c sha1.c -o sha1.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c sha256.c -o sha256.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c thread.c -o thread.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c tty.c -o tty.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c utf8.c -o utf8.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c utils.c -o utils.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c vt.c -o vt.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c vtparse.c -o vtparse.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c vtparse_table.c -o vtparse_table.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c win-utf8.c -o win-utf8.o
clang  -I"C:/PROGRA~1/R/R-devel/include" -DNDEBUG     -I"C:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/include"   -I../inst/include   -Wall -pedantic -c winfiles.c -o winfiles.o
clang -shared -s -static-libgcc -o cli.dll tmp.def ansi.o cleancall.o diff.o errors.o glue.o init.o inst.o keypress-unix.o keypress-win.o keypress.o md5.o progress-altrep.o progress.o sha1.o sha256.o thread.o tty.o utf8.o utils.o vt.o vtparse.o vtparse_table.o win-utf8.o winfiles.o -LC:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/lib -LC:/rtools43-aarch64/aarch64-w64-mingw32.static.posix/lib -LC:/PROGRA~1/R/R-devel/bin -lR
ld.lld: error: undefined symbol: clock_gettime
>>> referenced by progress.o:(clic__get_time)
>>> referenced by progress.o:(clic_get_time)

ld.lld: error: undefined symbol: nanosleep
>>> referenced by progress.o:(cli_progress_sleep)
>>> referenced by thread.o:(clic_thread_func)

ld.lld: error: undefined symbol: pthread_setcanceltype
>>> referenced by thread.o:(clic_thread_func)

ld.lld: error: undefined symbol: pthread_create
>>> referenced by thread.o:(cli__start_thread)

ld.lld: error: undefined symbol: pthread_cancel
>>> referenced by thread.o:(cli__kill_thread)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
no DLL was created
```