### PR TITLE
Only show first class in {.obj_type_friendly}

### DIFF
--- a/R/friendly-type.R
+++ b/R/friendly-type.R
@@ -23,7 +23,7 @@ friendly_type <- function(x, value = TRUE, length = FALSE) {
       } else {
         "a"
       }
-      return(paste0(prop, " {.cls {class(x)}} object"))
+      return(paste0(prop, " {.cls {class(x)[1]}} object"))
     }
   }
 


### PR DESCRIPTION
To display like rlang
https://github.com/r-lib/rlang/pull/1622

Let me know if you think this is reasonable, and if it requires NEWS.
```r
cli::cli_abort("{.obj_type_friendly {gt::gt(gt::exibble)}}")
Error:
! a <gt_tbl/list> object
```
With this PR (hopefully)
```r
cli::cli_abort("{.obj_type_friendly {gt::gt(gt::exibble)}}")
Error:
! a <gt_tbl> object
```
