### PR TITLE
Add advice for text + line + col + file hyperlink

### DIFF
--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -567,7 +567,20 @@ NULL
 #' ```{asciicast links-file-3}
 #' cli_text("... see line 5 in {.file ~/.Rprofile:5}.")
 #' ```
+#' 
+#' There is also support for displaying text and line numbers but the syntax
+#' is a bit different. You have to use `style_hyperlink()` with `params`.
+#' Make sure that `line` and `col` are numeric as they will be ignored otherwise.
 #'
+#' ```{asciicast links-file-4}
+#' link <- style_hyperlink(
+#'   text = "R profile at line 5",
+#'   url = "file://~/.Rprofile",
+#'   params = list(line = 5, col = 1)
+#' )
+#' cli_text("... see {link}")
+#' ```
+#' 
 #' ## Default handler
 #'
 #' In RStudio `file:` URLs open within RStudio. If you click on a file
@@ -579,7 +592,7 @@ NULL
 #' One issue with using `.href` file files is that it does not look great
 #' if hyperlinks are not available. This will be improved in the future:
 #'
-#' ```{asciicast links-file-4}
+#' ```{asciicast links-file-5}
 #' local({
 #'   withr::local_options(cli.hyperlink = FALSE)
 #'   prof <- path.expand("~/.Rprofile")


### PR DESCRIPTION
Until https://github.com/r-lib/cli/issues/601 is fixed.

I tried looking into fixing it, but couldn't figure it out due to the regexp.

I added this clarification about `line` and `col` being numeric, because I was once extracting regexp and forgot to convert to numeric, and they get ignored. 

```r
cli::style_hyperlink(
  text = "R profile at line 5",
  url = "file://~/.Rprofile",
  params = list(line = "5", col = "1")
)
```