### PR TITLE
Concrete demo of what I'm seeing

### DIFF
--- a/tests/testthat/_snaps/code.md
+++ b/tests/testthat/_snaps/code.md
@@ -34,3 +34,31 @@
       b
       c
 
+# Jenny's problem [plain]
+
+    Code
+      cli_code_wrapper("if (1) {true_val} else {false_val}")
+    Message
+      if (1) TRUE else 'FALSE'
+
+# Jenny's problem [ansi]
+
+    Code
+      cli_code_wrapper("if (1) {true_val} else {false_val}")
+    Message
+      [33mif[39m [33m([39m[35m1[39m[33m)[39m [35mTRUE[39m [33melse[39m [36m'FALSE'[39m
+
+# Jenny's problem [unicode]
+
+    Code
+      cli_code_wrapper("if (1) {true_val} else {false_val}")
+    Message
+      if (1) TRUE else 'FALSE'
+
+# Jenny's problem [fancy]
+
+    Code
+      cli_code_wrapper("if (1) {true_val} else {false_val}")
+    Message
+      [33mif[39m [33m([39m[35m1[39m[33m)[39m [35mTRUE[39m [33melse[39m [36m'FALSE'[39m
+

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -7,3 +7,14 @@ test_that_cli("issue #154", {
     cli_code("a\nb\nc")
   })
 })
+
+test_that_cli("Jenny's problem", {
+  cli_code_wrapper <- function(x, .envir = parent.frame()) {
+    x <- glue::glue(x, .envir = .envir)
+    cli_code(x, .envir = .envir) # <- passing .envir along is problematic
+  }
+
+  true_val <- "TRUE"
+  false_val <- "'FALSE'"
+  expect_snapshot(cli_code_wrapper("if (1) {true_val} else {false_val}"))
+})


### PR DESCRIPTION
As per slack discussion

This test passes when executed via `test_active_file()` or `test()` in the RStudio console, but fails in the RStudio build pane or in a terminal inside RStudio. It passes via any method when run via R in a (non-RStudio) terminal.

Update: the CI test failures seem to just be snapshot related and are not what I'm seeing, which I'll copy/paste below.

```
Error (test-code.R:19:3): Jenny's problem [ansi]
Error: RStudio not running
Backtrace:
     ▆
  1. └─testthat::expect_snapshot(cli_code_wrapper("if (1) {true_val} else {false_val}")) at test-code.R:19:3
  2.   └─testthat:::expect_snapshot_helper(...)
  3.     └─testthat:::snapshot_accept_hint(variant, snapshotter$file)
  4.       ├─base::paste0(...)
  5.       └─cli::format_inline("* Run {.run testthat::snapshot_accept('{name}')} to accept the change.")
  6.         └─cli::cli_fmt(...) at cli/R/cli.R:120:3
  7.           └─cli:::cli__fmt(rec, collapse, strip_newline) at cli/R/cli.R:91:3
  8.             ├─base::do.call(app[[msg$type]], msg$args) at cli/R/cli.R:61:5
  9.             └─cli (local) `<fn>`(text = `<cl_gl_dl>`)
 10.               └─cli:::clii_inline_text(app, text) at cli/R/cliapp.R:6:3
 11.                 └─app$xtext(text, wrap = FALSE) at cli/R/cliapp.R:171:3
 12.                   └─cli:::clii__xtext(...) at cli/R/cliapp.R:6:3
 13.                     └─style$fmt(text) at cli/R/internals.R:18:3
 14.                       └─cli::code_highlight(lines) at cli/R/themes.R:373:5
 15.                         ├─code_theme %||% code_theme_default() at cli/R/prettycode.R:41:3
 16.                         └─cli:::code_theme_default() at cli/R/prettycode.R:41:3
 17.                           └─cli:::code_theme_default_rstudio() at cli/R/prettycode.R:243:5
 18.                             └─cli:::get_rstudio_theme() at cli/R/prettycode.R:272:3
 19.                               ├─base::suppressWarnings(rstudioapi::getThemeInfo()) at cli/R/aaa-utils.R:166:3
 20.                               │ └─base::withCallingHandlers(...)
 21.                               └─rstudioapi::getThemeInfo()
 22.                                 └─rstudioapi::callFun("getThemeInfo")
 23.                                   └─rstudioapi::verifyAvailable()
 ```
