### PR TITLE
Handle non finite edge cases with pluralization()

### DIFF
--- a/R/pluralize.R
+++ b/R/pluralize.R
@@ -9,7 +9,11 @@ NULL
 make_quantity <- function(object) {
   val <- if (is.numeric(object)) {
     stopifnot(length(object) == 1)
-    as.integer(object)
+
+    if (is.finite(object))
+      as.integer(object)
+    else
+      object
   } else {
     length(object)
   }
@@ -87,13 +91,16 @@ process_plural <- function(qty, code) {
   parts <- strsplit(str_tail(code), "/", fixed = TRUE)[[1]]
   if (last_character(code) == "/") parts <- c(parts, "")
   if (length(parts) == 1) {
-    if (qty != 1) parts[1] else ""
+    if (is.finite(qty) & qty == 1) "" else parts[1]
   } else if (length(parts) == 2) {
-    if (qty == 1) parts[1] else parts[2]
-  } else if (length(parts) == 3) {
-    if (qty == 0) {
+    if (is.finite(qty) & qty == 1)
       parts[1]
-    } else if (qty == 1) {
+    else
+      parts[2]
+  } else if (length(parts) == 3) {
+    if (is.finite(qty) & qty == 0) {
+      parts[1]
+    } else if (is.finite(qty) & qty == 1) {
       parts[2]
     } else {
       parts[3]

--- a/tests/testthat/_snaps/pluralization.md
+++ b/tests/testthat/_snaps/pluralization.md
@@ -176,3 +176,96 @@
     Output
       9 word
 
+# issue 701
+
+    Code
+      print(pluralize("{NA} file{?s} expected"))
+    Output
+      NA file expected
+    Code
+      print(pluralize("{NA_character_} file{?s} expected"))
+    Output
+      NA file expected
+    Code
+      print(pluralize("{NA_real_} file{?s} expected"))
+    Output
+      NA files expected
+    Code
+      print(pluralize("{NA_integer_} file{?s} expected"))
+    Output
+      NA files expected
+    Code
+      print(pluralize("{NaN} file{?s} expected"))
+    Output
+      NaN files expected
+    Code
+      print(pluralize("{Inf} file{?s} expected"))
+    Output
+      Inf files expected
+    Code
+      print(pluralize("{-Inf} file{?s} expected"))
+    Output
+      -Inf files expected
+
+---
+
+    Code
+      print(pluralize("Found {NA} director{?y/ies}."))
+    Output
+      Found NA directory.
+    Code
+      print(pluralize("Found {NA_character_} director{?y/ies}."))
+    Output
+      Found NA directory.
+    Code
+      print(pluralize("Found {NA_real_} director{?y/ies}."))
+    Output
+      Found NA directories.
+    Code
+      print(pluralize("Found {NA_integer_} director{?y/ies}."))
+    Output
+      Found NA directories.
+    Code
+      print(pluralize("Found {NaN} director{?y/ies}."))
+    Output
+      Found NaN directories.
+    Code
+      print(pluralize("Found {Inf} director{?y/ies}."))
+    Output
+      Found Inf directories.
+    Code
+      print(pluralize("Found {-Inf} director{?y/ies}."))
+    Output
+      Found -Inf directories.
+
+---
+
+    Code
+      print(pluralize("Will remove {?no/the/the} {NA} package{?s}."))
+    Output
+      Will remove the NA package.
+    Code
+      print(pluralize("Will remove {?no/the/the} {NA_character_} package{?s}."))
+    Output
+      Will remove the NA package.
+    Code
+      print(pluralize("Will remove {?no/the/the} {NA_real_} package{?s}."))
+    Output
+      Will remove the NA packages.
+    Code
+      print(pluralize("Will remove {?no/the/the} {NA_integer_} package{?s}."))
+    Output
+      Will remove the NA packages.
+    Code
+      print(pluralize("Will remove {?no/the/the} {NaN} package{?s}."))
+    Output
+      Will remove the NaN packages.
+    Code
+      print(pluralize("Will remove {?no/the/the} {Inf} package{?s}."))
+    Output
+      Will remove the Inf packages.
+    Code
+      print(pluralize("Will remove {?no/the/the} {-Inf} package{?s}."))
+    Output
+      Will remove the -Inf packages.
+

--- a/tests/testthat/test-pluralization.R
+++ b/tests/testthat/test-pluralization.R
@@ -104,7 +104,7 @@ test_that("issue 158", {
   })
 })
 
-test_that("issue 701", {
+test_that("Edge cases for pluralize() (#701)", {
   expect_snapshot({
     # Should not be pluralized
     print(pluralize("{NA} file{?s} expected"))

--- a/tests/testthat/test-pluralization.R
+++ b/tests/testthat/test-pluralization.R
@@ -103,3 +103,44 @@ test_that("issue 158", {
     print(pluralize("{9} word{?A/B/}"))
   })
 })
+
+test_that("issue 701", {
+  expect_snapshot({
+    # Should not be pluralized
+    print(pluralize("{NA} file{?s} expected"))
+    print(pluralize("{NA_character_} file{?s} expected"))
+
+    # Should be pluralized
+    print(pluralize("{NA_real_} file{?s} expected"))
+    print(pluralize("{NA_integer_} file{?s} expected"))
+    print(pluralize("{NaN} file{?s} expected"))
+    print(pluralize("{Inf} file{?s} expected"))
+    print(pluralize("{-Inf} file{?s} expected"))
+  })
+
+  expect_snapshot({
+    # Should not be pluralized
+    print(pluralize("Found {NA} director{?y/ies}."))
+    print(pluralize("Found {NA_character_} director{?y/ies}."))
+
+    # Should be pluralized
+    print(pluralize("Found {NA_real_} director{?y/ies}."))
+    print(pluralize("Found {NA_integer_} director{?y/ies}."))
+    print(pluralize("Found {NaN} director{?y/ies}."))
+    print(pluralize("Found {Inf} director{?y/ies}."))
+    print(pluralize("Found {-Inf} director{?y/ies}."))
+  })
+
+  expect_snapshot({
+    # Should not be pluralized
+    print(pluralize("Will remove {?no/the/the} {NA} package{?s}."))
+    print(pluralize("Will remove {?no/the/the} {NA_character_} package{?s}."))
+
+    # Should be pluralized
+    print(pluralize("Will remove {?no/the/the} {NA_real_} package{?s}."))
+    print(pluralize("Will remove {?no/the/the} {NA_integer_} package{?s}."))
+    print(pluralize("Will remove {?no/the/the} {NaN} package{?s}."))
+    print(pluralize("Will remove {?no/the/the} {Inf} package{?s}."))
+    print(pluralize("Will remove {?no/the/the} {-Inf} package{?s}."))
+  })
+})


### PR DESCRIPTION
This is a draft resolution to #701 and some related edge cases. The issue seems to be more general than originally described with handling any of the non-finite values (including NAs).

The currently implemented behavior is the following:

* Numeric non-finite values (`NA_real_`, `NA_integer_`, `NaN`, `Inf` and `-Inf`) will be treated as a `qty` > 1 for pluralization purposes.

* Non-numeric NA values (`NA_character_` and `NA`) are treated as a non-numeric input so `qty` is based on the vector's length.

I've opted not to throw an error for numeric `NA`s or `NaN` cases since that seemed a bit severe but it also seems like a plausible outcome and happy to switch to that behavior if that is a better option.
