### PR TITLE
Include \r in the possible space characters used by ansi_strsplit()

### DIFF
--- a/R/ansiex.R
+++ b/R/ansiex.R
@@ -568,7 +568,7 @@ ansi_strwrap <- function(x, width = console_width(), indent = 0,
 
   # First we need to remove the multiple spaces, to make it easier to
   # map the strings later on. We do this per paragraph, to keep paragraphs.
-  pars <- strsplit(x, "\n[ \t\n]*\n", perl = TRUE)
+  pars <- strsplit(x, "\n[ \r\t\n]*\n", perl = TRUE)
   pars <- lapply(pars, ansi_trimws)
 
   # Within paragraphs, replace multiple spaces with one, except when there
@@ -577,11 +577,11 @@ ansi_strwrap <- function(x, width = console_width(), indent = 0,
   # some is outside, but for now, we'll live with this limitation.
   pars <- lapply(pars, function(s) {
     # First replace multiple spaces that are not at the end of a sentence
-    s <- gsub("(?<![.!?])[ \t\n][ \t\n]*", " ", s, perl = TRUE)
+    s <- gsub("(?<![.!?])[ \r\t\n][ \r\t\n]*", " ", s, perl = TRUE)
     # Handle multiple spaces at the end of a sentence
-    s <- gsub("(?<=[.!?])[ \t\n][ \t\n][ \t\n]*", "  ", s, perl = TRUE)
+    s <- gsub("(?<=[.!?])[ \r\t\n][ \r\t\n][ \r\t\n]*", "  ", s, perl = TRUE)
     # Handle simple space at the end of a sentence
-    gsub("(?<=[.!?])[ \t\n]", " ", s, perl = TRUE)
+    gsub("(?<=[.!?])[ \r\t\n]", " ", s, perl = TRUE)
   })
 
   # Put them back together
@@ -611,7 +611,7 @@ ansi_strwrap <- function(x, width = console_width(), indent = 0,
     } else if (xsc == xwc) {
       xsidx <- xsidx + 1L
       xwidx[2] <- xwidx[2] + 1L
-    } else if (xsc %in% c(" ", "\n", "\t")) {
+    } else if (xsc %in% c(" ", "\r", "\n", "\t")) {
       drop <- c(drop, xsidx)
       xsidx <- xsidx + 1L
     } else if (xwc == " ") {

--- a/tests/testthat/test-ansiex.R
+++ b/tests/testthat/test-ansiex.R
@@ -630,3 +630,26 @@ test_that_cli(configs = c("plain", "ansi"), "ansi_chartr", {
     cat_line(ansi_chartr(" R_", "-r*", x))
   }))
 })
+
+
+test_that("test handling of \\r in ansi_strwrap (#667) ", {
+  expect_equal(
+    ansi_strwrap(cli::col_red("foobar \r |")),
+    ansi_string(cli::col_red("foobar |"))
+  )
+
+  expect_equal(
+    ansi_strwrap(cli::col_red("foobar \n |")),
+    ansi_string(cli::col_red("foobar |"))
+  )
+
+  expect_equal(
+    ansi_strwrap(cli::col_red("foobar \r\n |")),
+    ansi_string(cli::col_red("foobar |"))
+  )
+
+  expect_equal(
+    ansi_strwrap(cli::col_red("foobar \r\n\r |")),
+    ansi_string(cli::col_red("foobar |"))
+  )
+})


### PR DESCRIPTION
This is a highly speculative fix for #667 because I can in no way claim to understand the underlying code used for the wrapping.

The changes amount to including `\r` with the other space characters and that is it, I am sure there are edge cases that I am not aware of that are being missed but the tests seem to pass for the moment.