### PR TITLE
Add link to rlang docs for cli_abort etc reference (#544)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -167,7 +167,12 @@ reference:
   - utf8_nchar
   - utf8_substr
 
-- title: Format and signal errors with cli formatting
+- title: Raising conditions with formatted cli messages
+  desc: |
+    This section documents cli functions for signalling 
+    errors, warnings or messages using 
+    abort(), warn() and inform() from 
+    [rlang](https://rlang.r-lib.org/reference/topic-condition-formatting.html)
   contents:
   - cli_abort
   - cli_inform


### PR DESCRIPTION
Updates title and adds description to function reference index section for signalling error, warnings and messages. Based on discussions for creating cli cheatsheet in (#544)