### PR TITLE
Add an alias of STRING_PTR_RO-->STRING_PTR in R<3.5.0

### DIFF
--- a/src/cli.h
+++ b/src/cli.h
@@ -8,6 +8,10 @@
 #include <Rinternals.h>
 #include <Rversion.h>
 
+#if R_VERSION < R_Version(3, 5, 0)
+#  define STRING_PTR_RO(x) STRING_PTR(x)
+#endif
+
 SEXP clic_diff_chr(SEXP a, SEXP b, SEXP max);
 
 SEXP clic_getppid(void);


### PR DESCRIPTION
Closes #724 

I think it's nice for {cli} to be available for "very old" R, so I don't see a need to bump the dependency just to get `STRING_PTR_RO()`.