### PR TITLE
Fix #621

### DIFF
--- a/R/aab-rstudio-detect.R
+++ b/R/aab-rstudio-detect.R
@@ -36,7 +36,7 @@ rstudio <- local({
     if (d$api) {
       ns <- asNamespace("rstudioapi")
       d$ver <- if (d$api) ns$getVersion()
-      new_api <- getNamespaceVersion(ns) >= "0.17.0"
+      new_api <- package_version(getNamespaceVersion(ns)) >= "0.17.0"
       d$desktop <- if (new_api) ns$getMode() else ns$versionInfo()$mode
     }
 

--- a/R/aab-rstudio-detect.R
+++ b/R/aab-rstudio-detect.R
@@ -36,11 +36,7 @@ rstudio <- local({
     if (d$api) {
       ns <- asNamespace("rstudioapi")
       d$ver <- if (d$api) ns$getVersion()
-
-      # Pull version from namespace rather than via `utils::packageVersion()`
-      # to avoid slowdown (see https://github.com/r-lib/rlang/pull/1657 and
-      # https://github.com/r-lib/rlang/issues/1422)
-      new_api <- ns[[".__NAMESPACE__."]][["spec"]][["version"]] >= "0.17.0"
+      new_api <- getNamespaceVersion(ns) >= "0.17.0"
       d$desktop <- if (new_api) ns$getMode() else ns$versionInfo()$mode
     }
 

--- a/R/aab-rstudio-detect.R
+++ b/R/aab-rstudio-detect.R
@@ -32,8 +32,17 @@ rstudio <- local({
       args = commandArgs(),
       search = search()
     )
-    d$ver <- if (d$api) asNamespace("rstudioapi")$getVersion()
-    d$desktop <- if (d$api) asNamespace("rstudioapi")$versionInfo()$mode
+
+    if (d$api) {
+      ns <- asNamespace("rstudioapi")
+      d$ver <- if (d$api) ns$getVersion()
+
+      # Pull version from namespace rather than via `utils::packageVersion()`
+      # to avoid slowdown (see https://github.com/r-lib/rlang/pull/1657 and
+      # https://github.com/r-lib/rlang/issues/1422)
+      new_api <- ns[[".__NAMESPACE__."]][["spec"]][["version"]] >= "0.17.0"
+      d$desktop <- if (new_api) ns$getMode() else ns$versionInfo()$mode
+    }
 
     d
   }


### PR DESCRIPTION
This commit conditions on the presence of rstudioapi 0.17.0. If satisfied then use the new getMode() function
(https://github.com/rstudio/rstudioapi/releases/tag/v0.17.0). Otherwise maintain the old behaviour.

Printing of a slowish ~data frame~ tibble in RStudio improved from ~18 seconds, to ~3 seconds with this commit and rstudioapi v0.17.0.