### PR TITLE
Fix flaky snapshot test

### DIFF
--- a/tests/testthat/test-progress-types.R
+++ b/tests/testthat/test-progress-types.R
@@ -35,7 +35,8 @@ test_that("tasks", {
     cli.spinner = NULL,
     cli.spinner_unicode = NULL,
     cli.progress_format_tasks = NULL,
-    cli.progress_format_tasks_nototal= NULL
+    cli.progress_format_tasks_nototal= NULL,
+    cli.width = Inf
   )
 
   fun <- function() {


### PR DESCRIPTION
I'm having one of these experiences where the local snapshot fails, due to linebreak issues. This is my usual fix, even thought it's ugly 😬 

https://github.com/r-lib/testthat/issues/1937