### PR TITLE
Make `x-r-whatever`-style hyperlinks configurable

### DIFF
--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -195,7 +195,6 @@ make_link_run <- function(txt) {
   text <- ifelse(is.na(mch$text), txt, mch$text)
   code <- ifelse(is.na(mch$url), txt, mch$url)
 
-  #browser()
   sprt <- ansi_hyperlink_types()$run
   if (!sprt) {
     return(vcapply(text, function(code1) format_inline("{.code {code1}}")))

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -193,23 +193,7 @@ make_link_run <- function(txt) {
     return(vcapply(text, function(code1) format_inline("{.code {code1}}")))
   }
 
-  custom_fmt <- get_config_chr("hyperlink_run_url_format")
-  if (is.null(custom_fmt)) {
-    if (identical(attr(sprt, "type"), "rstudio")) {
-      fmt_type <- "rstudio"
-    } else {
-      fmt_type <- "standard"
-    }
-  } else {
-    fmt_type <- "custom"
-  }
-
-  fmt <- switch(
-    fmt_type,
-    custom = custom_fmt,
-    rstudio = "ide:run:{code}",
-    standard = "x-r-run:{code}"
-  )
+  fmt <- get_hyperlink_format("run")
   style_hyperlink(text = text, url = glue(fmt))
 }
 

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -228,21 +228,16 @@ make_link_url <- function(txt) {
 make_link_vignette <- function(txt) {
   mch <- re_match(txt, "^\\[(?<text>.*)\\]\\((?<url>.*)\\)$")
   text <- ifelse(is.na(mch$text), txt, mch$text)
-  url <- ifelse(is.na(mch$url), txt, mch$url)
+  vignette <- ifelse(is.na(mch$url), txt, mch$url)
 
   sprt <- ansi_hyperlink_types()$vignette
-  if (sprt) {
-    scheme <- if (identical(attr(sprt, "type"), "rstudio")) {
-      "ide:vignette"
-    } else {
-      "x-r-vignette"
-    }
-    style_hyperlink(text = text, url = paste0(scheme, ":", url))
-
-  } else {
-    url2 <- vcapply(url, function(url1) format_inline("{.code vignette({url1})}"))
-    ifelse(text == url, url2, paste0(text, " (", url2, ")"))
+  if (!sprt) {
+    vignette2 <- vcapply(vignette, function(x) format_inline("{.code vignette({x})}"))
+    return(ifelse(text == vignette, vignette2, paste0(text, " (", vignette2, ")")))
   }
+
+  fmt <- get_hyperlink_format("vignette")
+  style_hyperlink(text = text, url = glue(fmt))
 }
 
 #' Terminal Hyperlinks

--- a/R/test.R
+++ b/R/test.R
@@ -112,6 +112,18 @@ test_that_cli <- function(desc, code,
         cli.hyperlink_help = links,
         cli.hyperlink_run = links,
         cli.hyperlink_vignette = links,
+        cli.hyperlink_run_url_format = NULL,
+        cli.hyperlink_help_url_format = NULL,
+        cli.hyperlink_vignette_url_format = NULL,
+      )
+      withr::local_envvar(
+        R_CLI_HYPERLINKS = NA_character_,
+        R_CLI_HYPERLINK_RUN = NA_character_,
+        R_CLI_HYPERLINK_HELP = NA_character_,
+        R_CLI_HYPERLINK_VIGNETTE = NA_character_,
+        R_CLI_HYPERLINK_RUN_URL_FORMAT = NA_character_,
+        R_CLI_HYPERLINK_HELP_URL_FORMAT = NA_character_,
+        R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT = NA_character_,
       )
       code_
     }, c(conf, list(code_ = code)))
@@ -131,6 +143,9 @@ local_clean_cli_context <- function(.local_envir = parent.frame()) {
     cli.hyperlink_run = NULL,
     cli.hyperlink_help = NULL,
     cli.hyperlink_vignette = NULL,
+    cli.hyperlink_run_url_format = NULL,
+    cli.hyperlink_help_url_format = NULL,
+    cli.hyperlink_vignette_url_format = NULL,
     cli.num_colors = NULL,
     cli.palette = NULL,
     crayon.enabled = NULL
@@ -138,6 +153,12 @@ local_clean_cli_context <- function(.local_envir = parent.frame()) {
   withr::local_envvar(
     .local_envir = .local_envir,
     R_CLI_HYPERLINKS = NA_character_,
+    R_CLI_HYPERLINK_RUN = NA_character_,
+    R_CLI_HYPERLINK_HELP = NA_character_,
+    R_CLI_HYPERLINK_VIGNETTE = NA_character_,
+    R_CLI_HYPERLINK_RUN_URL_FORMAT = NA_character_,
+    R_CLI_HYPERLINK_HELP_URL_FORMAT = NA_character_,
+    R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT = NA_character_,
     RSTUDIO_CLI_HYPERLINKS = NA_character_,
     R_CLI_NUM_COLORS = NA_character_,
     NO_COLOR = NA_character_,

--- a/R/test.R
+++ b/R/test.R
@@ -114,16 +114,12 @@ test_that_cli <- function(desc, code,
         cli.hyperlink_vignette = links,
         cli.hyperlink_run_url_format = NULL,
         cli.hyperlink_help_url_format = NULL,
-        cli.hyperlink_vignette_url_format = NULL,
+        cli.hyperlink_vignette_url_format = NULL
       )
       withr::local_envvar(
-        R_CLI_HYPERLINKS = NA_character_,
-        R_CLI_HYPERLINK_RUN = NA_character_,
-        R_CLI_HYPERLINK_HELP = NA_character_,
-        R_CLI_HYPERLINK_VIGNETTE = NA_character_,
         R_CLI_HYPERLINK_RUN_URL_FORMAT = NA_character_,
         R_CLI_HYPERLINK_HELP_URL_FORMAT = NA_character_,
-        R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT = NA_character_,
+        R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT = NA_character_
       )
       code_
     }, c(conf, list(code_ = code)))

--- a/tests/testthat/_snaps/links.md
+++ b/tests/testthat/_snaps/links.md
@@ -819,6 +819,13 @@
     Message
       `pkg::func()`
 
+# .fun with custom format [plain-all]
+
+    Code
+      cli_text("{.fun pkg::func}")
+    Message
+      `]8;;aaa-pkg::func-zzzpkg::func]8;;()`
+
 # {.help} [plain-none]
 
     Code
@@ -856,6 +863,13 @@
       cli_text("{.help {funcs}}")
     Message
       ]8;;x-r-help:pkg::fun1pkg::fun1]8;;, ]8;;x-r-help:pkg::fun2pkg::fun2]8;;, and ]8;;x-r-help:pkg::fun3pkg::fun3]8;;
+
+# .help with custom format [plain-all]
+
+    Code
+      cli_text("{.help pkg::fun}")
+    Message
+      ]8;;aaa-pkg::fun-zzzpkg::fun]8;;
 
 # {.href} [plain-none]
 
@@ -943,6 +957,13 @@
     Message
       ]8;;x-r-run:pkg::fun1()pkg::fun1()]8;;, ]8;;x-r-run:pkg::fun2()pkg::fun2()]8;;, and ]8;;x-r-run:pkg::fun3()pkg::fun3()]8;;
 
+# .run with custom format [plain-all]
+
+    Code
+      cli_text("{.run devtools::document()}")
+    Message
+      ]8;;aaa-devtools::document()-zzzdevtools::document()]8;;
+
 # {.topic} [plain-none]
 
     Code
@@ -980,6 +1001,13 @@
       cli_text("{.topic {topics}}")
     Message
       ]8;;x-r-help:pkg::topic1pkg::topic1]8;;, ]8;;x-r-help:pkg::topic2pkg::topic2]8;;, and ]8;;x-r-help:pkg::topic3pkg::topic3]8;;
+
+# .topic with custom format [plain-all]
+
+    Code
+      cli_text("{.topic pkg::fun}")
+    Message
+      ]8;;aaa-pkg::fun-zzzpkg::fun]8;;
 
 # {.url} [plain-none]
 
@@ -1091,4 +1119,11 @@
       cli_text("{.vignette {vignettes}}")
     Message
       ]8;;x-r-vignette:pkg::topic1pkg::topic1]8;;, ]8;;x-r-vignette:pkg::topic2pkg::topic2]8;;, and ]8;;x-r-vignette:pkg::topic3pkg::topic3]8;;
+
+# .vignette with custom format [plain-all]
+
+    Code
+      cli_text("{.vignette pkgdown::accessibility}")
+    Message
+      ]8;;aaa-pkgdown::accessibility-zzzpkgdown::accessibility]8;;
 

--- a/tests/testthat/test-ansi-hyperlink.R
+++ b/tests/testthat/test-ansi-hyperlink.R
@@ -391,3 +391,34 @@ test_that("get_config_chr() errors if option is not NULL or string", {
 
   expect_error(get_config_chr("something"), "is_string")
 })
+
+test_that("get_hyperlink_format() delivers custom format", {
+  local_clean_cli_context()
+
+  withr::local_options(
+    cli.hyperlink_run = TRUE,
+    cli.hyperlink_help = TRUE,
+    cli.hyperlink_vignette = TRUE
+  )
+
+  # env var is consulted after option, so start with env var
+  withr::local_envvar(
+    R_CLI_HYPERLINK_RUN_URL_FORMAT = "envvar{code}",
+    R_CLI_HYPERLINK_HELP_URL_FORMAT = "envvar{topic}",
+    R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT = "envvar{vignette}"
+  )
+
+  expect_equal(get_hyperlink_format("run"), "envvar{code}")
+  expect_equal(get_hyperlink_format("help"), "envvar{topic}")
+  expect_equal(get_hyperlink_format("vignette"), "envvar{vignette}")
+
+  withr::local_options(
+    cli.hyperlink_run_url_format = "option{code}",
+    cli.hyperlink_help_url_format = "option{topic}",
+    cli.hyperlink_vignette_url_format = "option{vignette}"
+  )
+
+  expect_equal(get_hyperlink_format("run"), "option{code}")
+  expect_equal(get_hyperlink_format("help"), "option{topic}")
+  expect_equal(get_hyperlink_format("vignette"), "option{vignette}")
+})

--- a/tests/testthat/test-ansi-hyperlink.R
+++ b/tests/testthat/test-ansi-hyperlink.R
@@ -253,7 +253,6 @@ test_that("rstudio links", {
     cli.hyperlink_run = TRUE,
     cli.hyperlink_vignette = TRUE
   )
-
   expect_snapshot(
     cli::cli_text("{.fun pkg::fun}")
   )

--- a/tests/testthat/test-ansi-hyperlink.R
+++ b/tests/testthat/test-ansi-hyperlink.R
@@ -240,6 +240,7 @@ test_that("iterm file links", {
 })
 
 test_that("rstudio links", {
+  local_clean_cli_context()
   withr::local_envvar(
     RSTUDIO = "1",
     RSTUDIO_SESSION_PID = Sys.getpid(),
@@ -252,6 +253,7 @@ test_that("rstudio links", {
     cli.hyperlink_run = TRUE,
     cli.hyperlink_vignette = TRUE
   )
+
   expect_snapshot(
     cli::cli_text("{.fun pkg::fun}")
   )

--- a/tests/testthat/test-ansi-hyperlink.R
+++ b/tests/testthat/test-ansi-hyperlink.R
@@ -371,3 +371,23 @@ test_that("ansi_hyperlink_types", {
   )
   expect_true(ansi_hyperlink_types()[["run"]])
 })
+
+test_that("get_config_chr() consults option, env var, then its default", {
+  local_clean_cli_context()
+
+  key <- "hyperlink_TYPE_url_format"
+
+  expect_null(get_config_chr(key))
+
+  withr::local_envvar(R_CLI_HYPERLINK_TYPE_URL_FORMAT = "envvar")
+  expect_equal(get_config_chr(key), "envvar")
+
+  withr::local_options(cli.hyperlink_type_url_format = "option")
+  expect_equal(get_config_chr(key), "option")
+})
+
+test_that("get_config_chr() errors if option is not NULL or string", {
+  withr::local_options(cli.something = FALSE)
+
+  expect_error(get_config_chr("something"), "is_string")
+})

--- a/tests/testthat/test-links.R
+++ b/tests/testthat/test-links.R
@@ -135,6 +135,13 @@ test_that_cli(configs = "plain", links = "all", "turning off help", {
   })
 })
 
+test_that_cli(configs = "plain", links = "all", ".fun with custom format", {
+  withr::local_options(cli.hyperlink_help_url_format = "aaa-{topic}-zzz")
+  expect_snapshot({
+    cli_text("{.fun pkg::func}")
+  })
+})
+
 # -- {.help} --------------------------------------------------------------
 
 test_that_cli(configs = "plain", links = c("all", "none"),
@@ -148,6 +155,13 @@ test_that_cli(configs = "plain", links = c("all", "none"),
   expect_snapshot({
     funcs <- paste0("pkg::fun", 1:3)
     cli_text("{.help {funcs}}")
+  })
+})
+
+test_that_cli(configs = "plain", links = "all", ".help with custom format", {
+  withr::local_options(cli.hyperlink_help_url_format = "aaa-{topic}-zzz")
+  expect_snapshot({
+    cli_text("{.help pkg::fun}")
   })
 })
 
@@ -188,6 +202,13 @@ test_that_cli(configs = "plain", links = c("all", "none"),
   })
 })
 
+test_that_cli(configs = "plain", links = "all", ".run with custom format", {
+  withr::local_options(cli.hyperlink_run_url_format = "aaa-{code}-zzz")
+  expect_snapshot({
+    cli_text("{.run devtools::document()}")
+  })
+})
+
 # -- {.topic} -------------------------------------------------------------
 
 test_that_cli(configs = "plain", links = c("all", "none"),
@@ -201,6 +222,13 @@ test_that_cli(configs = "plain", links = c("all", "none"),
   expect_snapshot({
     topics <- paste0("pkg::topic", 1:3)
     cli_text("{.topic {topics}}")
+  })
+})
+
+test_that_cli(configs = "plain", links = "all", ".topic with custom format", {
+  withr::local_options(cli.hyperlink_help_url_format = "aaa-{topic}-zzz")
+  expect_snapshot({
+    cli_text("{.topic pkg::fun}")
   })
 })
 
@@ -250,5 +278,12 @@ test_that_cli(configs = "plain", links = c("all", "none"),
   expect_snapshot({
     vignettes <- paste0("pkg::topic", 1:3)
     cli_text("{.vignette {vignettes}}")
+  })
+})
+
+test_that_cli(configs = "plain", links = "all", ".vignette with custom format", {
+  withr::local_options(cli.hyperlink_vignette_url_format = "aaa-{vignette}-zzz")
+  expect_snapshot({
+    cli_text("{.vignette pkgdown::accessibility}")
   })
 })

--- a/tests/testthat/test-progress-types.R
+++ b/tests/testthat/test-progress-types.R
@@ -9,7 +9,8 @@ test_that("iterator", {
     cli.spinner = NULL,
     cli.spinner_unicode = NULL,
     cli.progress_format_iterator = NULL,
-    cli.progress_format_iterator_nototal= NULL
+    cli.progress_format_iterator_nototal= NULL,
+    cli.width = Inf
   )
 
   fun <- function() {

--- a/vignettes/cli-config-internal.Rmd
+++ b/vignettes/cli-config-internal.Rmd
@@ -9,7 +9,7 @@ editor_options:
     wrap: sentence
 ---
 
-These are environment variables and options are for cli developers, users
+These environment variables and options are for cli developers. Users
 should not rely on them as they may change between cli releases.
 
 ## Internal environment variables

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -34,8 +34,6 @@ after that it will be removed.
 
 ### `cli.hyperlink` option and `R_CLI_HYPERLINKS` env var
 
-SIDE NOTE: THE "S" AT THE END R_CLI_HYPERLINKS IS REGRETTABLE, IN TERMS OF CONSISTENCY WITH RELATED CONFIG.
-
 Set this option or env var to `true`, `TRUE` or `True` to tell cli that the terminal supports ANSI hyperlinks.
 Leave this configuration unset (or set to anything else) when there is no hyperlink support.
 

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -12,14 +12,79 @@ editor_options:
 These are environment variables and options that users may set, to modify
 the behavior of cli.
 
-## User facing environment variables
+## Hyperlinks
+
+cli uses ANSI escape sequences to create hyperlinks.
+Specifically, cli creates [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) that have this syntax:
+
+```
+OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
+```
+
+Under the hood, [style_hyperlink()] is the helper that forms these links, but it is more common to request them indirectly via inline markup (documented in `help("links")`).
 
 ### `R_CLI_HYPERLINK_MODE`
 
 Set to `posix` to force generating POSIX compatible ANSI hyperlinks.
+This is about the specific operating system command (OSC) and string terminator (ST) used in hyperlinks.
+
 If not set, then RStudio compatible links are generated. This is a
 temporary crutch until RStudio handles POSIX hyperlinks correctly, and
 after that it will be removed.
+
+### `cli.hyperlink` option and `R_CLI_HYPERLINKS` env var
+
+SIDE NOTE: THE "S" AT THE END R_CLI_HYPERLINKS IS REGRETTABLE, IN TERMS OF CONSISTENCY WITH RELATED CONFIG.
+
+Set this option or env var to `true`, `TRUE` or `True` to tell cli that the terminal supports ANSI hyperlinks.
+Leave this configuration unset (or set to anything else) when there is no hyperlink support.
+
+The option `cli.hyperlink` takes precedence over the `R_CLI_HYPERLINKS` env var.
+
+### `cli.hyperlink_*` options and `R_CLI_HYPERLINK_*` env vars
+
+cli supports a few special types of hyperlink that don't just point to, e.g., a webpage or a file.
+These specialized hyperlinks cause R-specific actions to happen, such executing a bit of R code or opening specific documentation.
+
+Set the relevant option or env var to `true`, `TRUE`, or `True` to tell cli that the terminal is capable of implementing these specialized behaviours.
+Leave this configuration unset (or set to anything else) when there is no support for a specific type of hyperlink.
+
+| Action            | Example inline markup                                                                 | Option                   | Env var                    |
+|-------------------|---------------------------------------------------------------------------------------|--------------------------|----------------------------|
+|        Run R code | `{.run testthat::snapshot_review()}`                                                  | `cli.hyperlink_run`      | `R_CLI_HYPERLINK_RUN`      |
+| Open a help topic | `{.fun stats::lm}` `{.topic tibble::tibble_options}` `{.help [{.fun lm}](stats::lm)}` | `cli.hyperlink_help`     | `R_CLI_HYPERLINK_HELP`     |
+| Open a vignette   | `{.vignette tibble::types}`                                                           | `cli.hyperlink_vignette` | `R_CLI_HYPERLINK_VIGNETTE` |
+
+In all cases, the option takes priority over the corresponding env var.
+
+### `cli.hyperlink_*_url_format` options and `R_CLI_HYPERLINK_*_URL_FORMAT` env vars
+
+Recall the overall structure of cli's hyperlinks:
+
+```
+OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
+```
+
+The `URI` part has a default format for each type of hyperlink, but it is possible to provide a custom format via an option or an env var.
+If defined, the option takes priority over the env var.
+
+| Action            | Default URI format        | Customize via option                | Customize via env var                 |
+|-------------------|---------------------------|-------------------------------------|---------------------------------------|
+|        Run R code | `x-r-run:{code}`          | `cli.hyperlink_run_url_format`      | `R_CLI_HYPERLINK_RUN_URL_FORMAT`      |
+| Open a help topic | `x-r-help:{topic}`        | `cli.hyperlink_help_url_format`     | `R_CLI_HYPERLINK_HELP_URL_FORMAT`     |
+| Open a vignette   | `x-r-vignette:{vignette}` | `cli.hyperlink_vignette_url_format` | `R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT` |
+
+A format must be a glue-like template with the relevant placeholder in curly braces (`code`, `topic` or `vignette`).
+
+Here's an example of a custom URI format for runnable code, which is useful in an integrated Positron terminal:
+
+```
+positron://positron.positron-r/cli?command=x-r-run:{code}
+```
+
+(For backwards compatibility with older versions of RStudio, in some contexts, a legacy format is used, e.g. `ide:run:{code}`.)
+
+## User facing environment variables
 
 ### `NO_COLOR`
 
@@ -42,63 +107,6 @@ See [is_dynamic_tty()].
 
 Set to a positive integer to assume a given number of colors.
 See [num_ansi_colors()].
-
-### `R_CLI_HYPERLINKS`
-
-THE "S" AT THE END HERE IS REGRETTABLE, IN TERMS OF CONSISTENCY WITH RELATED CONFIG.
-
-Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
-ANSI hyperlinks.
-Set to anything else to assume no hyperlink support.
-See [style_hyperlink()].
-If the option `cli.hyperlink` is defined, it takes priority over this env var.
-
-### `R_CLI_HYPERLINK_RUN`, `R_CLI_HYPERLINK_HELP`, `R_CLI_HYPERLINK_VIGNETTE`
-
-Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
-that specific type of specialized hyperlink.
-Set to anything else to signal a lack of support.
-The `R_CLI_HYPERLINKS` env var indicates that the terminal supports a certain type of hyperlink syntax, whereas these env vars signal that the environment also knows how to execute R code or open documentation.
-
-Here is the relationship between these env vars and the classes applied via inline markup:
-
-* `R_CLI_HYPERLINK_RUN` enables links such as:
-  - `{.run testthat::snapshot_review()}`
-* `R_CLI_HYPERLINK_HELP` enables links such as:
-  - `{.fun stats::lm}`
-  - `{.topic tibble::tibble_options}`
-  - `{.help [{.fun lm}](stats::lm)}`
-* `R_CLI_HYPERLINK_VIGNETTE` enables links such as:
-  - `{.vignette tibble::types}`
-
-If defined, the options `cli.hyperlink_run`, `cli.hyperlink_help` and `cli.hyperlink_vignette` take priority over these env var counterparts.
-
-### `R_CLI_HYPERLINK_RUN_URL_FORMAT`, `R_CLI_HYPERLINK_HELP_URL_FORMAT`, `R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT`
-
-cli uses [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) that have this syntax:
-
-```
-OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
-```
-
-These env vars relate to the form of the `URI` for these specialized hyperlinks.
-These are the current default formats:
-
-* `x-r-run:{code}`
-* `x-r-help:{topic}`
-* `x-r-vignette:{vignette}`
-
-(For backwards compatibility with older versions of RStudio, in some contexts, a legacy format is used, e.g. `ide:run:{code}`.)
-
-These `R_CLI_HYPERLINK_*_URL_FORMAT` env vars allow an environment to provide a custom format to cli.
-A format must be a glue-like template with the relevant placeholder in curly braces (`code`, `topic` or `vignette`).
-Example of a custom URI format for runnable code in an integrated Positron terminal:
-
-```
-positron://positron.positron-r/cli?command=x-r-run:{code}
-```
-
-If defined, the options `cli.hyperlink_run_url_format`, `cli.hyperlink_help_url_format` and `cli.hyperlink_vignette_url_format` take priority over these env var counterparts.
 
 ## User facing options
 
@@ -156,61 +164,6 @@ See [is_dynamic_tty()].
 
 Whether the cli status bar should try to hide the cursor on terminals.
 Set the `FALSE` if the hidden cursor causes issues.
-
-### `cli.hyperlink`
-
-Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
-ANSI hyperlinks.
-Set to anything else to assume no hyperlink support.
-See [style_hyperlink()].
-The same result can be achieved with the `R_CLI_HYPERLINKS` env var, however this option takes precedence.
-
-### `cli.hyperlink_run`, `cli.hyperlink_help`, `cli.hyperlink_vignette`
-
-Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
-that specific type of specialized hyperlink.
-Set to anything else to signal a lack of support.
-The `cli.hyperlink` option indicates that the terminal supports a certain type of hyperlink syntax, whereas these options signal that the environment also knows how to execute R code or open documentation.
-
-Here is the relationship between these options and the classes applied via inline markup:
-
-* `cli.hyperlink_run` enables links such as:
-  - `{.run testthat::snapshot_review()}`
-* `cli.hyperlink_help` enables links such as:
-  - `{.fun stats::lm}`
-  - `{.topic tibble::tibble_options}`
-  - `{.help [{.fun lm}](stats::lm)}`
-* `cli.hyperlink_vignette` enables links such as:
-  - `{.vignette tibble::types}`
-
-The same result can be achieved with the env vars `R_CLI_HYPERLINK_RUN`, `R_CLI_HYPERLINK_HELP`, and `R_CLI_HYPERLINK_VIGNETTE`, however these options take precedence.
-
-### `cli.hyperlink_run_url_format`, `cli.hyperlink_help_url_format`, `cli.hyperlink_vignette_url_format`
-
-cli uses [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) that have this syntax:
-
-```
-OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
-```
-
-These options relate to the form of the `URI` for these specialized hyperlinks.
-These are the current default formats:
-
-* `x-r-run:{code}`
-* `x-r-help:{topic}`
-* `x-r-vignette:{vignette}`
-
-(For backwards compatibility with older versions of RStudio, in some contexts, a legacy format is used, e.g. `ide:run:{code}`.)
-
-These `cli.hyperlink_*_url_format` options allow an environment to provide a custom format to cli.
-A format must be a glue-like template with the relevant placeholder in curly braces (`code`, `topic` or `vignette`).
-Example of a custom URI format for runnable code in an integrated Positron terminal:
-
-```
-positron://positron.positron-r/cli?command=x-r-run:{code}
-```
-
-This configuration can also be communicated via the env vars `R_CLI_HYPERLINK_RUN_URL_FORMAT`, `R_CLI_HYPERLINK_HELP_URL_FORMAT`, and `R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT`, however these options take precedence.
 
 ### `cli.ignore_unknown_rstudio_theme`
 

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -9,7 +9,7 @@ editor_options:
     wrap: sentence
 ---
 
-These are environment variables and options that uses may set, to modify
+These are environment variables and options that users may set, to modify
 the behavior of cli.
 
 ## User facing environment variables
@@ -45,10 +45,60 @@ See [num_ansi_colors()].
 
 ### `R_CLI_HYPERLINKS`
 
+THE "S" AT THE END HERE IS REGRETTABLE, IN TERMS OF CONSISTENCY WITH RELATED CONFIG.
+
 Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
 ANSI hyperlinks.
 Set to anything else to assume no hyperlink support.
 See [style_hyperlink()].
+If the option `cli.hyperlink` is defined, it takes priority over this env var.
+
+### `R_CLI_HYPERLINK_RUN`, `R_CLI_HYPERLINK_HELP`, `R_CLI_HYPERLINK_VIGNETTE`
+
+Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
+that specific type of specialized hyperlink.
+Set to anything else to signal a lack of support.
+The `R_CLI_HYPERLINKS` env var indicates that the terminal supports a certain type of hyperlink syntax, whereas these env vars signal that the environment also knows how to execute R code or open documentation.
+
+Here is the relationship between these env vars and the classes applied via inline markup:
+
+* `R_CLI_HYPERLINK_RUN` enables links such as:
+  - `{.run testthat::snapshot_review()}`
+* `R_CLI_HYPERLINK_HELP` enables links such as:
+  - `{.fun stats::lm}`
+  - `{.topic tibble::tibble_options}`
+  - `{.help [{.fun lm}](stats::lm)}`
+* `R_CLI_HYPERLINK_VIGNETTE` enables links such as:
+  - `{.vignette tibble::types}`
+
+If defined, the options `cli.hyperlink_run`, `cli.hyperlink_help` and `cli.hyperlink_vignette` take priority over these env var counterparts.
+
+### `R_CLI_HYPERLINK_RUN_URL_FORMAT`, `R_CLI_HYPERLINK_HELP_URL_FORMAT`, `R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT`
+
+cli uses [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) that have this syntax:
+
+```
+OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
+```
+
+These env vars relate to the form of the `URI` for these specialized hyperlinks.
+These are the current default formats:
+
+* `x-r-run:{code}`
+* `x-r-help:{topic}`
+* `x-r-vignette:{vignette}`
+
+(For backwards compatibility with older versions of RStudio, in some contexts, a legacy format is used, e.g. `ide:run:{code}`.)
+
+These `R_CLI_HYPERLINK_*_URL_FORMAT` env vars allow an environment to provide a custom format to cli.
+A format must be a glue-like template with the relevant placeholder in curly braces (`code`, `topic` or `vignette`).
+Example of a custom URI format for runnable code in an integrated Positron terminal:
+
+```
+positron://positron.positron-r/cli?command=x-r-run:{code}
+```
+
+If defined, the options `cli.hyperlink_run_url_format`, `cli.hyperlink_help_url_format` and `cli.hyperlink_vignette_url_format` take priority over these env var counterparts.
 
 ## User facing options
 

--- a/vignettes/cli-config-user.Rmd
+++ b/vignettes/cli-config-user.Rmd
@@ -163,6 +163,54 @@ Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
 ANSI hyperlinks.
 Set to anything else to assume no hyperlink support.
 See [style_hyperlink()].
+The same result can be achieved with the `R_CLI_HYPERLINKS` env var, however this option takes precedence.
+
+### `cli.hyperlink_run`, `cli.hyperlink_help`, `cli.hyperlink_vignette`
+
+Set to `true`, `TRUE` or `True` to tell cli that the terminal supports
+that specific type of specialized hyperlink.
+Set to anything else to signal a lack of support.
+The `cli.hyperlink` option indicates that the terminal supports a certain type of hyperlink syntax, whereas these options signal that the environment also knows how to execute R code or open documentation.
+
+Here is the relationship between these options and the classes applied via inline markup:
+
+* `cli.hyperlink_run` enables links such as:
+  - `{.run testthat::snapshot_review()}`
+* `cli.hyperlink_help` enables links such as:
+  - `{.fun stats::lm}`
+  - `{.topic tibble::tibble_options}`
+  - `{.help [{.fun lm}](stats::lm)}`
+* `cli.hyperlink_vignette` enables links such as:
+  - `{.vignette tibble::types}`
+
+The same result can be achieved with the env vars `R_CLI_HYPERLINK_RUN`, `R_CLI_HYPERLINK_HELP`, and `R_CLI_HYPERLINK_VIGNETTE`, however these options take precedence.
+
+### `cli.hyperlink_run_url_format`, `cli.hyperlink_help_url_format`, `cli.hyperlink_vignette_url_format`
+
+cli uses [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) that have this syntax:
+
+```
+OSC 8 ; {OPTIONAL PARAMS } ; {URI} ST {LINK TEXT} OSC 8 ; ; ST
+```
+
+These options relate to the form of the `URI` for these specialized hyperlinks.
+These are the current default formats:
+
+* `x-r-run:{code}`
+* `x-r-help:{topic}`
+* `x-r-vignette:{vignette}`
+
+(For backwards compatibility with older versions of RStudio, in some contexts, a legacy format is used, e.g. `ide:run:{code}`.)
+
+These `cli.hyperlink_*_url_format` options allow an environment to provide a custom format to cli.
+A format must be a glue-like template with the relevant placeholder in curly braces (`code`, `topic` or `vignette`).
+Example of a custom URI format for runnable code in an integrated Positron terminal:
+
+```
+positron://positron.positron-r/cli?command=x-r-run:{code}
+```
+
+This configuration can also be communicated via the env vars `R_CLI_HYPERLINK_RUN_URL_FORMAT`, `R_CLI_HYPERLINK_HELP_URL_FORMAT`, and `R_CLI_HYPERLINK_VIGNETTE_URL_FORMAT`, however these options take precedence.
 
 ### `cli.ignore_unknown_rstudio_theme`
 


### PR DESCRIPTION
Relates to https://github.com/posit-dev/positron/pull/5231

This is about making cli hyperlinks work when positron-r carries out package dev tasks, such as `devtools::test()` in an integrated terminal. An extension can contribute a URI handler, but only URIs with a very specific format are routed into the handler.