### PR TITLE
Bump dev version and add NEWS bullet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cli
 Title: Helpers for Developing Command Line Interfaces
-Version: 3.6.3.9000
+Version: 3.6.3.9001
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre")),
     person("Hadley", "Wickham", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cli (development version)
 
+* The format of the URI part of "run", "help" and "vignette" hyperlinks can now
+  be configured via options and env vars (@jennybc, #739).
+
 * `cli_progress_bar()` now accepts `total` = Inf or -Inf which mimics the behavior    of when `total` is NA.
 
 * `num_ansi_colors()` now does not warn in Emacs if the `INSIDE_EMACS`


### PR DESCRIPTION
This really should have been part of #739, sorry.

I know we usually don't bump dev version, but it would help me in Positron if we do it in this case. In these integrated terminals I want to leave hyperlinks turned off, if I know they'll be broken, and turned on, if I know they'll work.