### PR TITLE
typo in cli hyperlink help page

### DIFF
--- a/R/cliapp-docs.R
+++ b/R/cliapp-docs.R
@@ -422,7 +422,7 @@ NULL
 #'
 #' # Note: hyperlinks are currently experimental
 #'
-#' The details of the styles that create hyperlinks will prrobably change
+#' The details of the styles that create hyperlinks will probably change
 #' in the near future, based on user feedback.
 #'
 #' # About the links in this manual page


### PR DESCRIPTION
Spotted that while reading the doc. 

Couldn't `devtools::document()` on Windows due to this error

````
> devtools::document()
ℹ Updating cli documentation
ℹ Loading cli
✖ cliapp-docs.R:179: @section has mismatched braces or quotes.
Warning message:
Failed to source `man/roxygen/meta.R` 
Error in `collapse()`:
! length(key) == length(value) is not TRUE
Hide Traceback
     ▆
  1. └─devtools::document()
  2.   └─roxygen2::roxygenise(pkg$path, roclets)
  3.     └─base::lapply(...)
  4.       ├─roxygen2 (local) FUN(X[[i]], ...)
  5.       └─roxygen2:::roclet_process.roclet_rd(X[[i]], ...)
  6.         ├─roxygen2:::block_to_rd(block, base_path, env)
  7.         └─roxygen2:::block_to_rd.roxy_block(block, base_path, env)
  8.           └─rd$add(roxy_tag_rd(tag, env = env, base_path = base_path))
  9.             └─self$add_section(x, block, overwrite = overwrite)
 10.               ├─base::merge(self$get_section(type), section, block = block)
 11.               └─roxygen2:::merge.rd_section_section(...)
 12.                 └─roxygen2:::collapse(...)
 13.                   └─base::stopifnot(length(key) == length(value))
 ````
 
 with
````
> packageVersion("roxygen2")
[1] ‘7.3.2.9000’
````

It seems to be due to `{` in
https://github.com/r-lib/cli/blob/cbb3424f296f58822629487a729d5d987a91104b/R/cliapp-docs.R#L187

Anyhow, roxygen2 issue ? 