### PR TITLE
New bullet styles for TODOs and questions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * New `{.num}` and `{.bytes}` inline styles to format numbers
   and bytes (@m-muecke, #644, #588, #643).
+  
+* New bullet styles for TODOs ("[]") and questions ("?") 
+  (@jameslairdsmith, #779).
 
 # cli 3.6.5
 

--- a/R/bullets.R
+++ b/R/bullets.R
@@ -22,6 +22,8 @@
 #' * `x`: Item with a ref cross, like [cli_alert_danger()].
 #' * `!`: Item with a yellow exclamation mark, like [cli_alert_warning()].
 #' * `i`: Info item, like [cli_alert_info()].
+#' * `[]`: TODO item.
+#' * `?`: Question item.
 #'
 #' You can define new item type by simply defining theming for the
 #' corresponding `bullet-<name>` classes.
@@ -35,7 +37,9 @@
 #'   "v" = "success",
 #'   "x" = "danger",
 #'   "!" = "warning",
-#'   "i" = "info"
+#'   "i" = "info",
+#'   "[]"= "TODO",
+#'   "?" = "question
 #' ))
 #' ```
 #'

--- a/R/themes.R
+++ b/R/themes.R
@@ -149,6 +149,14 @@ builtin_theme <- function(dark = getOption("cli.theme_dark", "auto")) {
       "text-exdent" = 2,
       before = function(x) paste0(col_cyan(symbol$info), " ")
     ),
+    ".bullets .bullet-?" = list(
+      "text-exdent" = 2,
+      before = function(x) paste0(col_red(symbol$fancy_question_mark), " ")
+    ),
+    ".bullets .bullet-[]" = list(
+      "text-exdent" = 2,
+      before = function(x) paste0(col_red(symbol$checkbox_off), " ")
+    ),
     ".bullets .bullet-*" = list(
       "text-exdent" = 2,
       before = function(x) paste0(col_cyan(symbol$bullet), " ")

--- a/tests/testthat/_snaps/bullets.md
+++ b/tests/testthat/_snaps/bullets.md
@@ -2,7 +2,7 @@
 
     Code
       cli_bullets(c("noindent", ` ` = "space", v = "success", x = "danger", `!` = "warning",
-        i = "info", `*` = "bullet", `>` = "arrow"))
+        i = "info", `*` = "bullet", `>` = "arrow", `[]` = "TODO", `?` = "question"))
     Message
       noindent
         space
@@ -12,12 +12,14 @@
       i info
       * bullet
       > arrow
+      [ ] TODO
+      (?) question
 
 # bullets [ansi]
 
     Code
       cli_bullets(c("noindent", ` ` = "space", v = "success", x = "danger", `!` = "warning",
-        i = "info", `*` = "bullet", `>` = "arrow"))
+        i = "info", `*` = "bullet", `>` = "arrow", `[]` = "TODO", `?` = "question"))
     Message
       noindent
         space
@@ -27,12 +29,14 @@
       [36mi[39m info
       [36m*[39m bullet
       > arrow
+      [31m[ ][39m TODO
+      [31m(?)[39m question
 
 # bullets [unicode]
 
     Code
       cli_bullets(c("noindent", ` ` = "space", v = "success", x = "danger", `!` = "warning",
-        i = "info", `*` = "bullet", `>` = "arrow"))
+        i = "info", `*` = "bullet", `>` = "arrow", `[]` = "TODO", `?` = "question"))
     Message
       noindent
         space
@@ -42,12 +46,14 @@
       ℹ info
       • bullet
       → arrow
+      ☐ TODO
+      ❓ question
 
 # bullets [fancy]
 
     Code
       cli_bullets(c("noindent", ` ` = "space", v = "success", x = "danger", `!` = "warning",
-        i = "info", `*` = "bullet", `>` = "arrow"))
+        i = "info", `*` = "bullet", `>` = "arrow", `[]` = "TODO", `?` = "question"))
     Message
       noindent
         space
@@ -57,13 +63,16 @@
       [36mℹ[39m info
       [36m•[39m bullet
       → arrow
+      [31m☐[39m TODO
+      [31m❓[39m question
 
 # bullets glue [plain]
 
     Code
       cli_bullets(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
         x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
-        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}", `[]` = "TODO {.key {1:3}}",
+        `?` = "question {.key {1:3}}"))
     Message
       noindent [1], [2], and [3]
         space [1], [2], and [3]
@@ -73,13 +82,16 @@
       i info [1], [2], and [3]
       * bullet [1], [2], and [3]
       > arrow [1], [2], and [3]
+      [ ] TODO [1], [2], and [3]
+      (?) question [1], [2], and [3]
 
 # bullets glue [ansi]
 
     Code
       cli_bullets(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
         x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
-        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}", `[]` = "TODO {.key {1:3}}",
+        `?` = "question {.key {1:3}}"))
     Message
       noindent [34m[1][39m, [34m[2][39m, and [34m[3][39m
         space [34m[1][39m, [34m[2][39m, and [34m[3][39m
@@ -89,13 +101,16 @@
       [36mi[39m info [34m[1][39m, [34m[2][39m, and [34m[3][39m
       [36m*[39m bullet [34m[1][39m, [34m[2][39m, and [34m[3][39m
       > arrow [34m[1][39m, [34m[2][39m, and [34m[3][39m
+      [31m[ ][39m TODO [34m[1][39m, [34m[2][39m, and [34m[3][39m
+      [31m(?)[39m question [34m[1][39m, [34m[2][39m, and [34m[3][39m
 
 # bullets glue [unicode]
 
     Code
       cli_bullets(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
         x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
-        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}", `[]` = "TODO {.key {1:3}}",
+        `?` = "question {.key {1:3}}"))
     Message
       noindent [1], [2], and [3]
         space [1], [2], and [3]
@@ -105,13 +120,16 @@
       ℹ info [1], [2], and [3]
       • bullet [1], [2], and [3]
       → arrow [1], [2], and [3]
+      ☐ TODO [1], [2], and [3]
+      ❓ question [1], [2], and [3]
 
 # bullets glue [fancy]
 
     Code
       cli_bullets(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
         x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
-        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}", `[]` = "TODO {.key {1:3}}",
+        `?` = "question {.key {1:3}}"))
     Message
       noindent [34m[1][39m, [34m[2][39m, and [34m[3][39m
         space [34m[1][39m, [34m[2][39m, and [34m[3][39m
@@ -121,12 +139,14 @@
       [36mℹ[39m info [34m[1][39m, [34m[2][39m, and [34m[3][39m
       [36m•[39m bullet [34m[1][39m, [34m[2][39m, and [34m[3][39m
       → arrow [34m[1][39m, [34m[2][39m, and [34m[3][39m
+      [31m☐[39m TODO [34m[1][39m, [34m[2][39m, and [34m[3][39m
+      [31m❓[39m question [34m[1][39m, [34m[2][39m, and [34m[3][39m
 
 # bullets wrapping [plain]
 
     Code
       cli_bullets(c(txt, ` ` = txt, v = txt, x = txt, `!` = txt, i = txt, `*` = txt,
-        `>` = txt))
+        `>` = txt, `[]` = txt, `?` = txt))
     Message
       This is some text that is longer than the width. This is some text that is
       longer than the width. This is some text that is longer than the width.
@@ -144,12 +164,16 @@
         longer than the width. This is some text that is longer than the width.
       > This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
+      [ ] This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
+      (?) This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
 
 # bullets wrapping [ansi]
 
     Code
       cli_bullets(c(txt, ` ` = txt, v = txt, x = txt, `!` = txt, i = txt, `*` = txt,
-        `>` = txt))
+        `>` = txt, `[]` = txt, `?` = txt))
     Message
       This is some text that is longer than the width. This is some text that is
       longer than the width. This is some text that is longer than the width.
@@ -167,12 +191,16 @@
         longer than the width. This is some text that is longer than the width.
       > This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
+      [31m[ ][39m This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
+      [31m(?)[39m This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
 
 # bullets wrapping [unicode]
 
     Code
       cli_bullets(c(txt, ` ` = txt, v = txt, x = txt, `!` = txt, i = txt, `*` = txt,
-        `>` = txt))
+        `>` = txt, `[]` = txt, `?` = txt))
     Message
       This is some text that is longer than the width. This is some text that is
       longer than the width. This is some text that is longer than the width.
@@ -190,12 +218,16 @@
         longer than the width. This is some text that is longer than the width.
       → This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
+      ☐ This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
+      ❓ This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
 
 # bullets wrapping [fancy]
 
     Code
       cli_bullets(c(txt, ` ` = txt, v = txt, x = txt, `!` = txt, i = txt, `*` = txt,
-        `>` = txt))
+        `>` = txt, `[]` = txt, `?` = txt))
     Message
       This is some text that is longer than the width. This is some text that is
       longer than the width. This is some text that is longer than the width.
@@ -212,5 +244,9 @@
       [36m•[39m This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
       → This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
+      [31m☐[39m This is some text that is longer than the width. This is some text that is
+        longer than the width. This is some text that is longer than the width.
+      [31m❓[39m This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
 

--- a/tests/testthat/test-bullets.R
+++ b/tests/testthat/test-bullets.R
@@ -10,7 +10,9 @@ test_that_cli("bullets", {
     "!" = "warning",
     "i" = "info",
     "*" = "bullet",
-    ">" = "arrow"
+    ">" = "arrow",
+    "[]"= "TODO",
+    "?" = "question"
   )))
 })
 
@@ -23,7 +25,9 @@ test_that_cli("bullets glue", {
     "!" = "warning {.key {1:3}}",
     "i" = "info {.key {1:3}}",
     "*" = "bullet {.key {1:3}}",
-    ">" = "arrow {.key {1:3}}"
+    ">" = "arrow {.key {1:3}}",
+    "[]"= "TODO {.key {1:3}}",
+    "?" = "question {.key {1:3}}"
   )))
 })
 
@@ -37,6 +41,8 @@ test_that_cli("bullets wrapping", {
     "!" = txt,
     "i" = txt,
     "*" = txt,
-    ">" = txt
+    ">" = txt,
+    "[]"= txt,
+    "?" = txt
   )))
 })


### PR DESCRIPTION
Fixes #779. 

Also touches on the subject matter of the usethis vignette ["Converting usethis's UI to use cli"](https://usethis.r-lib.org/articles/ui-cli-conversion.html) because of the TODOs.

Proposed new syntax:

``` r
cli_bullets(c("?" = "This is a question", "[]" = "This is a TODO"))
#> ❓ This is a question
#> ☐ This is a TODO
```


Some outstanding questions:

- Do we want to use the fancy question mark instead of the regular one?
- Is red the correct colour? It felt correct to me for the TODO given that `usethis::ui_todo()` used red as well.
- The usethis vignette proposes the underscore `"_"` as the LHS for TODO instead of `"[]"`. The `"[]"` feels more natural to me, but it is two characters whereas all the others are one.

Other things.

- Using roxygen2 (even the development version) seems to be broken for me because of a problem unrelated to the PR. It's in the "cliapp-docs.R".