### PR TITLE
Fix custom progress bar example to print the format_done message

### DIFF
--- a/R/progress-client.R
+++ b/R/progress-client.R
@@ -230,6 +230,7 @@
 #'       "{col_green(symbol$tick)} Downloaded {pb_total} files ",
 #'       "in {pb_elapsed}."
 #'     ),
+#'     clear = FALSE,
 #'     total = length(urls)
 #'   )
 #'   for (url in urls) {

--- a/man/cli_progress_bar.Rd
+++ b/man/cli_progress_bar.Rd
@@ -347,6 +347,7 @@ variables in the calling function:
       "\{col_green(symbol$tick)\} Downloaded \{pb_total\} files ",
       "in \{pb_elapsed\}."
     ),
+    clear = FALSE,
     total = length(urls)
   )
   for (url in urls) \{


### PR DESCRIPTION
This replaces a double comma with `clear = FALSE`, to address #783.

Fixes #783.