### PR TITLE
Make code_highlight() handle tabs ('\t') correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * New `{.num}` and `{.bytes}` inline styles to format numbers
   and bytes (@m-muecke, #644, #588, #643).
 
+* `code_highlight()` handles tab characters (`\t`) correctly (@mcol, #783).
+
 # cli 3.6.5
 
 * `code_highlight()` supports long strings and symbols

--- a/tests/testthat/_snaps/prettycode.md
+++ b/tests/testthat/_snaps/prettycode.md
@@ -223,3 +223,17 @@
     Output
       [1m\[22m(x) x * 2
 
+# strings with tabs [plain]
+
+    Code
+      code_highlight("x\t + 1")
+    Output
+      [1] "x\t + 1"
+
+# strings with tabs [ansi]
+
+    Code
+      code_highlight("x\t + 1")
+    Output
+      [1] "x\t \033[33m+\033[39m \033[35m1\033[39m"
+

--- a/tests/testthat/test-prettycode.R
+++ b/tests/testthat/test-prettycode.R
@@ -145,6 +145,11 @@ test_that("replace_in_place", {
     replace_in_place("1234567890", c(1, 5), c(6, 10), c("A", "B")),
     "AB"
   )
+
+  expect_equal(
+    replace_in_place("x\t + 1", c(1, 10, 12), c(1, 10, 12), c("x", "+", "1")),
+    "x\t + 1"
+  )
 })
 
 test_that("replace_in_place corner cases", {
@@ -262,6 +267,11 @@ test_that_cli(configs = "ansi", "new language features, lambda functions", {
   expect_snapshot(
     cat(code_highlight('\\(x) x * 2', list(reserved = "bold")))
   )
+})
+
+test_that_cli(configs = c("plain", "ansi"), "strings with tabs", {
+  expect_snapshot(
+      code_highlight("x\t + 1"))
 })
 
 test_that("code_highlight() works on long strings and symbols", {


### PR DESCRIPTION
This moves the existing function `substr_with_tabs()` at file level, so it can be called by `replace_in_place()`.

Fixes #754.