### PR TITLE
Silently ignore clear in cli_progress_step()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * New `{.num}` and `{.bytes}` inline styles to format numbers
   and bytes (@m-muecke, #644, #588, #643).
 
+* Silently ignore the `clear` argument if used in `cli_progress_step()`
+  (@mcol, #785).
+
 # cli 3.6.5
 
 * `code_highlight()` supports long strings and symbols

--- a/R/progress-client.R
+++ b/R/progress-client.R
@@ -789,7 +789,8 @@ cli_progress_message <- function(
 #' @param current Passed to [cli_progress_bar()].
 #' @param .auto_close Passed to [cli_progress_bar()].
 #' @param .envir Passed to [cli_progress_bar()].
-#' @param ... Passed to [cli_progress_bar()].
+#' @param ... Passed to [cli_progress_bar()] (with the exclusion of `clear`,
+#'   which is always `FALSE`).
 #'
 #' @seealso This function supports [inline markup][inline-markup].
 #' @family progress bar functions
@@ -819,18 +820,20 @@ cli_progress_step <- function(
 
   opt <- options(cli.progress_show_after = 0)
   on.exit(options(opt), add = TRUE)
-  id <- cli_progress_bar(
-    type = "custom",
-    format = format,
-    format_done = format_done,
-    format_failed = format_failed,
-    clear = FALSE,
-    current = current,
-    .auto_close = .auto_close,
-    .envir = .envir,
-    ...
-  )
-
+  cli_progress_bar_strip_clear <- function(..., clear) {
+    cli_progress_bar(
+        type = "custom",
+        format = format,
+        format_done = format_done,
+        format_failed = format_failed,
+        clear = FALSE,
+        current = current,
+        .auto_close = .auto_close,
+        .envir = .envir,
+        ...
+    )
+  }
+  id <- cli_progress_bar_strip_clear(...)
   cli_progress_update(id = id, force = TRUE, .envir = .envir)
 
   invisible(id)

--- a/man/cli_progress_step.Rd
+++ b/man/cli_progress_step.Rd
@@ -42,7 +42,8 @@ class for steps with a spinner.}
 
 \item{.envir}{Passed to \code{\link[=cli_progress_bar]{cli_progress_bar()}}.}
 
-\item{...}{Passed to \code{\link[=cli_progress_bar]{cli_progress_bar()}}.}
+\item{...}{Passed to \code{\link[=cli_progress_bar]{cli_progress_bar()}} (with
+the exclusion of `clear`, which is always `FALSE`).}
 }
 \description{
 This is a simplified progress bar, a single (dynamic)

--- a/tests/testthat/_snaps/progress-message.md
+++ b/tests/testthat/_snaps/progress-message.md
@@ -49,6 +49,15 @@
       [3] "\n"                           "\ri Second step\033[K\r"     
       [5] "\rv Second step [1s]\033[K\r" "\n"                          
 
+# cli_progress_step ignores clear
+
+    Code
+      msgs
+    Output
+      [1] "\ri First step\033[K\r"       "\rv First step [1s]\033[K\r" 
+      [3] "\n"                           "\ri Second step\033[K\r"     
+      [5] "\rv Second step [1s]\033[K\r" "\n"                          
+
 # cli_progress_step error
 
     Code

--- a/tests/testthat/test-progress-message.R
+++ b/tests/testthat/test-progress-message.R
@@ -59,6 +59,17 @@ test_that("cli_progress_step", {
   expect_snapshot(msgs)
 })
 
+test_that("cli_progress_step ignores clear", {
+  withr::local_options(cli.dynamic = TRUE, cli.ansi = TRUE)
+  suppressWarnings(testthat::local_reproducible_output())
+  fun <- function() {
+    cli_progress_step("First step", clear = TRUE)
+    cli_progress_step("Second step", clear = FALSE)
+  }
+  msgs <- fix_times(capture_cli_messages(fun()))
+  expect_snapshot(msgs)
+})
+
 test_that("cli_progress_step error", {
   if (getRversion() < "3.5.0") skip("Needs R 3.5.0")
   fun <- function() {


### PR DESCRIPTION
This is the best way I found to ignore a `...` argument (inspired by [this StackOverflow question](https://stackoverflow.com/questions/7028385/can-i-remove-an-element-in-dot-dot-dot-and-pass-it-on)). Most of the code change is just reindentation.

Fixes #785.