### PR TITLE
Fix pluralization if the value exceeds .Machine$integer.max

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * New `{.num}` and `{.bytes}` inline styles to format numbers
   and bytes (@m-muecke, #644, #588, #643).
 
+* Make `pluralize()` support values exceeding `.Machine$integer.max` (@mcol,
+  #773).
+
 # cli 3.6.5
 
 * `code_highlight()` supports long strings and symbols

--- a/R/pluralize.R
+++ b/R/pluralize.R
@@ -9,7 +9,10 @@ make_quantity <- function(object) {
   val <- if (is.numeric(object)) {
     stopifnot(length(object) == 1)
 
-    if (is.finite(object)) as.integer(object) else object
+    if (is.finite(object) && abs(object) <= .Machine$integer.max)
+      as.integer(object)
+    else
+      object
   } else {
     length(object)
   }

--- a/tests/testthat/_snaps/pluralization.md
+++ b/tests/testthat/_snaps/pluralization.md
@@ -292,3 +292,18 @@
     Output
       Will remove the -Inf packages.
 
+# issue 773
+
+    Code
+      print(pluralize("{.Machine$integer.max} value{?s}"))
+    Output
+      2147483647 values
+    Code
+      print(pluralize("{.Machine$integer.max + 1} value{?s}"))
+    Output
+      2147483648 values
+    Code
+      print(pluralize("{-1L * .Machine$integer.max - 1} value{?s}"))
+    Output
+      -2147483648 values
+

--- a/tests/testthat/test-pluralization.R
+++ b/tests/testthat/test-pluralization.R
@@ -134,3 +134,12 @@ test_that("Edge cases for pluralize() (#701)", {
     print(pluralize("Will remove {?no/the/the} {-Inf} package{?s}."))
   })
 })
+
+test_that("issue 773", {
+  expect_snapshot({
+    # Should be pluralized
+    print(pluralize("{.Machine$integer.max} value{?s}"))
+    print(pluralize("{.Machine$integer.max + 1} value{?s}"))
+    print(pluralize("{-1L * .Machine$integer.max - 1} value{?s}"))
+  })
+})


### PR DESCRIPTION
Fixes #773.