### PR TITLE
Escape single '<' and '>' in text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * New `{.num}` and `{.bytes}` inline styles to format numbers
   and bytes (@m-muecke, #644, #588, #643).
 
+* Fix escaping of `<>` so that `cli_bullets_raw()` doesn't attempt to
+  perform string interpolation on them (@mcol, #789).
+
 # cli 3.6.5
 
 * `code_highlight()` supports long strings and symbols

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,8 @@ has_packages <- function(pkgs) {
 cli_escape <- function(x) {
   x <- gsub("{", "{{", x, fixed = TRUE)
   x <- gsub("}", "}}", x, fixed = TRUE)
+  x <- gsub("<", "<<", x, fixed = TRUE)
+  x <- gsub(">", ">>", x, fixed = TRUE)
   x
 }
 

--- a/tests/testthat/_snaps/bullets.md
+++ b/tests/testthat/_snaps/bullets.md
@@ -214,3 +214,99 @@
       → This is some text that is longer than the width. This is some text that is
         longer than the width. This is some text that is longer than the width.
 
+# bullets_raw glue [plain]
+
+    Code
+      cli_bullets_raw(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
+        x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+    Message
+      noindent {{.key {{1:3}}}}
+        space {{.key {{1:3}}}}
+      v success {{.key {{1:3}}}}
+      x danger {{.key {{1:3}}}}
+      ! warning {{.key {{1:3}}}}
+      i info {{.key {{1:3}}}}
+      * bullet {{.key {{1:3}}}}
+      > arrow {{.key {{1:3}}}}
+
+# bullets_raw glue [ansi]
+
+    Code
+      cli_bullets_raw(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
+        x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+    Message
+      noindent {{.key {{1:3}}}}
+        space {{.key {{1:3}}}}
+      [32mv[39m success {{.key {{1:3}}}}
+      [31mx[39m danger {{.key {{1:3}}}}
+      [33m![39m warning {{.key {{1:3}}}}
+      [36mi[39m info {{.key {{1:3}}}}
+      [36m*[39m bullet {{.key {{1:3}}}}
+      > arrow {{.key {{1:3}}}}
+
+# bullets_raw glue [unicode]
+
+    Code
+      cli_bullets_raw(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
+        x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+    Message
+      noindent {{.key {{1:3}}}}
+        space {{.key {{1:3}}}}
+      ✔ success {{.key {{1:3}}}}
+      ✖ danger {{.key {{1:3}}}}
+      ! warning {{.key {{1:3}}}}
+      ℹ info {{.key {{1:3}}}}
+      • bullet {{.key {{1:3}}}}
+      → arrow {{.key {{1:3}}}}
+
+# bullets_raw glue [fancy]
+
+    Code
+      cli_bullets_raw(c("noindent {.key {1:3}}", ` ` = "space {.key {1:3}}", v = "success {.key {1:3}}",
+        x = "danger {.key {1:3}}", `!` = "warning {.key {1:3}}", i = "info {.key {1:3}}",
+        `*` = "bullet {.key {1:3}}", `>` = "arrow {.key {1:3}}"))
+    Message
+      noindent {{.key {{1:3}}}}
+        space {{.key {{1:3}}}}
+      [32m✔[39m success {{.key {{1:3}}}}
+      [31m✖[39m danger {{.key {{1:3}}}}
+      [33m![39m warning {{.key {{1:3}}}}
+      [36mℹ[39m info {{.key {{1:3}}}}
+      [36m•[39m bullet {{.key {{1:3}}}}
+      → arrow {{.key {{1:3}}}}
+
+# bullets_raw handles <> (#789) [plain]
+
+    Code
+      cli_bullets_raw(c("{.field field} <x>", "{.field field} <<x>>"))
+    Message
+      {{.field field}} <x>
+      {{.field field}} <<x>>
+
+# bullets_raw handles <> (#789) [ansi]
+
+    Code
+      cli_bullets_raw(c("{.field field} <x>", "{.field field} <<x>>"))
+    Message
+      {{.field field}} <x>
+      {{.field field}} <<x>>
+
+# bullets_raw handles <> (#789) [unicode]
+
+    Code
+      cli_bullets_raw(c("{.field field} <x>", "{.field field} <<x>>"))
+    Message
+      {{.field field}} <x>
+      {{.field field}} <<x>>
+
+# bullets_raw handles <> (#789) [fancy]
+
+    Code
+      cli_bullets_raw(c("{.field field} <x>", "{.field field} <<x>>"))
+    Message
+      {{.field field}} <x>
+      {{.field field}} <<x>>
+

--- a/tests/testthat/test-bullets.R
+++ b/tests/testthat/test-bullets.R
@@ -40,3 +40,23 @@ test_that_cli("bullets wrapping", {
     ">" = txt
   )))
 })
+
+test_that_cli("bullets_raw glue", {
+  expect_snapshot(cli_bullets_raw(c(
+    "noindent {.key {1:3}}",
+    " " = "space {.key {1:3}}",
+    "v" = "success {.key {1:3}}",
+    "x" = "danger {.key {1:3}}",
+    "!" = "warning {.key {1:3}}",
+    "i" = "info {.key {1:3}}",
+    "*" = "bullet {.key {1:3}}",
+    ">" = "arrow {.key {1:3}}"
+  )))
+})
+
+test_that_cli("bullets_raw handles <> (#789)", {
+  expect_snapshot(cli_bullets_raw(c(
+    "{.field field} <x>",
+    "{.field field} <<x>>"
+  )))
+})


### PR DESCRIPTION
This prevents `cli_bullet_raw()` from evaluating variables inside `<>`, which would lead to a crash, as the parent environment by design is not passed along.

Fixes #789.