### PR TITLE
Fix issue with links using fs::path() (#683)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Suggests:
     testthat (>= 3.2.0),
     tibble,
     whoami,
-    withr
+    withr,
+    fs
 Config/Needs/website:
     r-lib/asciicast,
     bench,

--- a/R/ansi-hyperlink.R
+++ b/R/ansi-hyperlink.R
@@ -243,6 +243,10 @@ make_link_help <- function(txt) {
 # -- {.href} --------------------------------------------------------------
 
 make_link_href <- function(txt) {
+  # Addresses #681 - if already linked, strip link and re-link
+  linked <- grepl("\007|\033\\\\", txt)
+  txt[linked] <- ansi_strip(txt[linked])
+
   mch <- re_match(txt, "^\\[(?<text>.*)\\]\\((?<url>.*)\\)$")
   text <- ifelse(is.na(mch$text), txt, mch$text)
   url <- ifelse(is.na(mch$url), txt, mch$url)
@@ -263,6 +267,10 @@ make_link_href <- function(txt) {
 # -- {.run} ---------------------------------------------------------------
 
 make_link_run <- function(txt) {
+  # Addresses #681 - if already linked, strip link and re-link
+  linked <- grepl("\007|\033\\\\", txt)
+  txt[linked] <- ansi_strip(txt[linked])
+
   mch <- re_match(txt, "^\\[(?<text>.*)\\]\\((?<url>.*)\\)$")
   text <- ifelse(is.na(mch$text), txt, mch$text)
   code <- ifelse(is.na(mch$url), txt, mch$url)

--- a/tests/testthat/_snaps/links.md
+++ b/tests/testthat/_snaps/links.md
@@ -1127,3 +1127,135 @@
     Message
       ]8;;aaa-pkgdown::accessibility-zzzpkgdown::accessibility]8;;
 
+# {.run} and {.href} with fs_path [plain-none]
+
+    Code
+      cli_text("{.run ['hi mom']({fs::path(path)})}")
+    Message
+      `'hi mom'`
+    Code
+      cli_text("{.run {fs::path(path)}}")
+    Message
+      ''`~/Desktop/foo.R`''
+
+---
+
+    Code
+      cli_text("{.href [link]({fs::path(path)})}")
+    Message
+      link (<'~/Desktop/foo.R'>)
+    Code
+      cli_text("{.href {fs::path(path)}}")
+    Message
+      ''<~/Desktop/foo.R>''
+
+---
+
+    Code
+      cli_text("{.file {fs::path(path)}}")
+    Message
+      '~/Desktop/foo.R'
+    Code
+      cli_text("{.path {fs::path(path)}}")
+    Message
+      '~/Desktop/foo.R'
+
+# {.run} and {.href} with fs_path [fancy-none]
+
+    Code
+      cli_text("{.run ['hi mom']({fs::path(path)})}")
+    Message
+      `'hi mom'`
+    Code
+      cli_text("{.run {fs::path(path)}}")
+    Message
+      '[34m'`~/Desktop/foo.R`'[39m'
+
+---
+
+    Code
+      cli_text("{.href [link]({fs::path(path)})}")
+    Message
+      link ([3m[34m<~/Desktop/foo.R>[39m[23m)
+    Code
+      cli_text("{.href {fs::path(path)}}")
+    Message
+      '[34m'[3m<~/Desktop/foo.R>[23m'[39m'
+
+---
+
+    Code
+      cli_text("{.file {fs::path(path)}}")
+    Message
+      [34m~/Desktop/foo.R[39m
+    Code
+      cli_text("{.path {fs::path(path)}}")
+    Message
+      [34m~/Desktop/foo.R[39m
+
+# {.run} and {.href} with fs_path [plain-all]
+
+    Code
+      cli_text("{.run ['hi mom']({fs::path(path)})}")
+    Message
+      ]8;;x-r-run:'~/Desktop/foo.R''hi mom']8;;
+    Code
+      cli_text("{.run {fs::path(path)}}")
+    Message
+      ']8;;x-r-run:~/Desktop/foo.R~/Desktop/foo.R]8;;'
+
+---
+
+    Code
+      cli_text("{.href [link]({fs::path(path)})}")
+    Message
+      ]8;;'~/Desktop/foo.R'link]8;;
+    Code
+      cli_text("{.href {fs::path(path)}}")
+    Message
+      ''<]8;;~/Desktop/foo.R~/Desktop/foo.R]8;;>''
+
+---
+
+    Code
+      cli_text("{.file {fs::path(path)}}")
+    Message
+      ']8;;file:///Users/rundel/Desktop/foo.R~/Desktop/foo.R]8;;'
+    Code
+      cli_text("{.path {fs::path(path)}}")
+    Message
+      ']8;;file:///Users/rundel/Desktop/foo.R~/Desktop/foo.R]8;;'
+
+# {.run} and {.href} with fs_path [fancy-all]
+
+    Code
+      cli_text("{.run ['hi mom']({fs::path(path)})}")
+    Message
+      ]8;;x-r-run:~/Desktop/foo.R'hi mom']8;;
+    Code
+      cli_text("{.run {fs::path(path)}}")
+    Message
+      ]8;;x-r-run:~/Desktop/foo.R[34m~/Desktop/foo.R[39m]8;;
+
+---
+
+    Code
+      cli_text("{.href [link]({fs::path(path)})}")
+    Message
+      ]8;;~/Desktop/foo.Rlink]8;;
+    Code
+      cli_text("{.href {fs::path(path)}}")
+    Message
+      '[34m'[3m<]8;;~/Desktop/foo.R~/Desktop/foo.R]8;;>[23m'[39m'
+
+---
+
+    Code
+      cli_text("{.file {fs::path(path)}}")
+    Message
+      ]8;;file:///Users/rundel/Desktop/foo.R[34m~/Desktop/foo.R[39m]8;;
+    Code
+      cli_text("{.path {fs::path(path)}}")
+    Message
+      ]8;;file:///Users/rundel/Desktop/foo.R[34m~/Desktop/foo.R[39m]8;;
+

--- a/tests/testthat/test-links.R
+++ b/tests/testthat/test-links.R
@@ -236,6 +236,7 @@ test_that_cli(configs = "plain", links = "all", ".run with custom format", {
   })
 })
 
+
 # -- {.topic} -------------------------------------------------------------
 
 test_that_cli(configs = "plain", links = c("all", "none"), "{.topic}", {
@@ -322,6 +323,37 @@ test_that_cli(
     )
     expect_snapshot({
       cli_text("{.vignette pkgdown::accessibility}")
+    })
+  }
+)
+
+
+# -- Issue #681 - fs::path weirdness -------------------------------------
+
+test_that_cli(
+  configs = c("plain", "fancy"),
+  links = c("all", "none"),
+  "{.run} and {.href} with fs_path",
+  {
+    skip_if_not_installed("fs")
+
+    path <- "~/Desktop/foo.R"
+
+    # Not working
+    expect_snapshot({
+      cli_text("{.run ['hi mom']({fs::path(path)})}")
+      cli_text("{.run {fs::path(path)}}")
+    })
+
+    expect_snapshot({
+      cli_text("{.href [link]({fs::path(path)})}")
+      cli_text("{.href {fs::path(path)}}")
+    })
+
+    # Working
+    expect_snapshot({
+      cli_text("{.file {fs::path(path)}}")
+      cli_text("{.path {fs::path(path)}}")
     })
   }
 )


### PR DESCRIPTION
This is a pass at addressing the issue referenced in #683 - my understanding of the problem is that the default cli theme is causing the fs_path object to first be rendered as a link and then there is a second pass by `.href` or `.run` that tries to wrap that in a new link and these don't get along.

My proposed solution is just a quick check at the beginning of `make_link_href()` and `make_link_run()` for the presence of an existing link and if detected then using `ansi_strip()` to remove the existing link before generating the new link. This may be a bit crude, and might nuke other things it shouldn't.

There are probably edge cases that I have not considered but I tried testing all of the other link methods and they already had some kind of existing link detection I believe.

Adding `fs` to suggests seemed like the path of least resistance but if that is not desirable then it should be avoidable by more carefully constructing the tests.

The major issue seems to be resolved but I am not 100% on if the output is exactly as desired in all test cases but everything looked reasonable to me based on the snapshots.
