### PR TITLE
Clarify a situation where console width cannot be determined

### DIFF
--- a/R/width.R
+++ b/R/width.R
@@ -20,9 +20,10 @@
 #' * We are _not_ using the `RSTUDIO_CONSOLE_WIDTH` environment variable
 #'   if we are in the RStudio console.
 #'
-#' If we cannot determine the size of the terminal or console window, then
-#' we use the `width` option. If the `width` option is not set, then
-#' we return 80L.
+#' If we cannot determine the size of the terminal or console window (e.g. if
+#' `console_width()` is called in a startup `.Rprofile` script before a console
+#' is present), then we use the `width` option. If the `width` option is not
+#' set, then we return 80L.
 #'
 #' @return Integer scalar, the console with, in number of characters.
 #'
@@ -102,7 +103,9 @@ tty_size <- function() {
 }
 
 terminal_width <- function() {
-  if (isTRUE(clienv$notaconsole)) return(NULL)
+  if (isTRUE(clienv$notaconsole)) {
+    return(NULL)
+  }
   w <- tryCatch(
     tty_size()[["width"]],
     error = function(e) {
@@ -112,7 +115,9 @@ terminal_width <- function() {
   )
 
   # this is probably a pty that does not set the width, use st sensible
-  if (!is.null(w) && w == 0) w <- 80L
+  if (!is.null(w) && w == 0) {
+    w <- 80L
+  }
   w
 }
 

--- a/man/console_width.Rd
+++ b/man/console_width.Rd
@@ -35,9 +35,10 @@ get garbled.
 if we are in the RStudio console.
 }
 
-If we cannot determine the size of the terminal or console window, then
-we use the \code{width} option. If the \code{width} option is not set, then
-we return 80L.
+If we cannot determine the size of the terminal or console window (e.g. if
+\code{console_width()} is called in a startup \code{.Rprofile} script before a console
+is present), then we use the \code{width} option. If the \code{width} option is not
+set, then we return 80L.
 }
 \examples{
 console_width()


### PR DESCRIPTION
In #578, a user found a situation where `cli::console_width()` was unable to determine the console width because it was run in an `.Rprofile` startup script that couldn't see RStudio's console yet. This clarifies that situation in the documentation.

