### PR TITLE
Added `cli_vec()` info to semantic cli vignette RE: inline cli text

### DIFF
--- a/vignettes/semantic-cli.Rmd
+++ b/vignettes/semantic-cli.Rmd
@@ -211,6 +211,17 @@ x <- Sys.time()
 cli_text("Hey {.var x} has class {.cls {class(x)}}")
 ```
 
+You can also use `cli_vec()`'s `style =` argument to customize inline separators to be passed into `cli_text()`:
+
+```{asciicast}
+v <- cli_vec(
+  c("foo", "bar", "foobar", "more", "nonsensical", "words"),
+  style = list("vec-sep" = " & ", "vec-last" = " !!!! ")
+)
+
+cli_text("My list: {v}.")
+```
+
 ## Non-breaking spaces
 
 Use `\u00a0` to create a non-breaking space.


### PR DESCRIPTION
- # Fixes 619
- Added addition to 