### PR TITLE
feat: add `duration` and `time_ago` to theme  #814

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cli (development version)
 
+* New `{.duration}` and `{.time_ago}` inline styles to format durations
+  and relative times (@jjjermiah, #814).
+
 # cli 3.6.6
 
 * New `{.num}` and `{.bytes}` inline styles to format numbers

--- a/R/simple-theme.R
+++ b/R/simple-theme.R
@@ -144,16 +144,7 @@ simple_theme <- function(dark = getOption("cli.theme_dark", "auto")) {
     span.var = simple_theme_code(dark),
     span.envvar = simple_theme_code(dark),
 
-    span.timestamp = list(before = "[", after = "]", color = "grey"),
-    span.duration = list(
-      before = "[",
-      after = "]",
-      color = "grey",
-      transform = function(x) format_time$pretty_sec(as.numeric(x))
-    ),
-    span.time_ago = list(
-      transform = function(x) format_time_ago$time_ago(as.POSIXct(as.numeric(x), origin = "1970-01-01"))
-    )
+    span.timestamp = list(before = "[", after = "]", color = "grey")
   )
 }
 

--- a/R/simple-theme.R
+++ b/R/simple-theme.R
@@ -144,7 +144,16 @@ simple_theme <- function(dark = getOption("cli.theme_dark", "auto")) {
     span.var = simple_theme_code(dark),
     span.envvar = simple_theme_code(dark),
 
-    span.timestamp = list(before = "[", after = "]", color = "grey")
+    span.timestamp = list(before = "[", after = "]", color = "grey"),
+    span.duration = list(
+      before = "[",
+      after = "]",
+      color = "grey",
+      transform = function(x) format_time$pretty_sec(as.numeric(x))
+    ),
+    span.time_ago = list(
+      transform = function(x) format_time_ago$time_ago(as.POSIXct(as.numeric(x), origin = "1970-01-01"))
+    )
   )
 }
 

--- a/R/themes.R
+++ b/R/themes.R
@@ -267,6 +267,15 @@ builtin_theme <- function(dark = getOption("cli.theme_dark", "auto")) {
     ),
     span.num = list(
       transform = function(x) format_num$pretty_num(as.numeric(x))
+    ),
+    span.duration = list(
+      before = "[",
+      after = "]",
+      color = "grey",
+      transform = function(x) format_time$pretty_sec(as.numeric(x))
+    ),
+    span.time_ago = list(
+      transform = function(x) format_time_ago$time_ago(as.POSIXct(as.numeric(x), origin = "1970-01-01"))
     )
   )
 }

--- a/R/themes.R
+++ b/R/themes.R
@@ -269,13 +269,13 @@ builtin_theme <- function(dark = getOption("cli.theme_dark", "auto")) {
       transform = function(x) format_num$pretty_num(as.numeric(x))
     ),
     span.duration = list(
-      before = "[",
-      after = "]",
-      color = "grey",
-      transform = function(x) format_time$pretty_sec(as.numeric(x))
+      transform = function(x) {
+        if (inherits(x, "difftime")) units(x) <- "secs"
+        format_time$pretty_sec(as.numeric(x))
+      }
     ),
     span.time_ago = list(
-      transform = function(x) format_time_ago$time_ago(as.POSIXct(as.numeric(x), origin = "1970-01-01"))
+      transform = function(x) format_time_ago$time_ago(as.POSIXct(x, origin = "1970-01-01"))
     )
   )
 }

--- a/tests/testthat/_snaps/inline-2.md
+++ b/tests/testthat/_snaps/inline-2.md
@@ -458,7 +458,7 @@
     Output
       [1] "--- 10 k, 20 k, 30 k, and 40 k ---"
 
-# .duration formats numeric seconds
+# .duration
 
     Code
       format_inline("--- {.duration 0.042} ---")
@@ -472,8 +472,16 @@
       format_inline("--- {.duration 3661} ---")
     Output
       [1] "--- 1h 1m 1s ---"
+    Code
+      format_inline("{.duration {as.difftime(1.5, units = 'mins')}}")
+    Output
+      [1] "1m 30s"
+    Code
+      format_inline("{.duration {as.difftime(1, units = 'hours')}}")
+    Output
+      [1] "1h"
 
-# .time_ago accepts numeric, POSIXct, and POSIXlt inputs
+# .time_ago
 
     Code
       t <- as.numeric(Sys.time() - 120)

--- a/tests/testthat/_snaps/inline-2.md
+++ b/tests/testthat/_snaps/inline-2.md
@@ -473,13 +473,15 @@
     Output
       [1] "--- 1h 1m 1s ---"
     Code
-      format_inline("{.duration {as.difftime(1.5, units = 'mins')}}")
+      dt_mins <- as.difftime(1.5, units = "mins")
+      format_inline("{.duration {dt_mins}}")
     Output
       [1] "1m 30s"
     Code
-      format_inline("{.duration {as.difftime(1, units = 'hours')}}")
+      dt_days <- as.difftime(30, units = "days")
+      format_inline("{.duration {dt_days}}")
     Output
-      [1] "1h"
+      [1] "30d"
 
 # .time_ago
 

--- a/tests/testthat/_snaps/inline-2.md
+++ b/tests/testthat/_snaps/inline-2.md
@@ -458,3 +458,36 @@
     Output
       [1] "--- 10 k, 20 k, 30 k, and 40 k ---"
 
+# .duration formats numeric seconds
+
+    Code
+      format_inline("--- {.duration 0.042} ---")
+    Output
+      [1] "--- 42ms ---"
+    Code
+      format_inline("--- {.duration 90} ---")
+    Output
+      [1] "--- 1m 30s ---"
+    Code
+      format_inline("--- {.duration 3661} ---")
+    Output
+      [1] "--- 1h 1m 1s ---"
+
+# .time_ago accepts numeric, POSIXct, and POSIXlt inputs
+
+    Code
+      t <- as.numeric(Sys.time() - 120)
+      format_inline("{.time_ago {t}}")
+    Output
+      [1] "2 minutes ago"
+    Code
+      t <- Sys.time() - 120
+      format_inline("{.time_ago {t}}")
+    Output
+      [1] "2 minutes ago"
+    Code
+      t <- as.POSIXlt(Sys.time() - 120)
+      format_inline("{.time_ago {t}}")
+    Output
+      [1] "2 minutes ago"
+

--- a/tests/testthat/test-inline-2.R
+++ b/tests/testthat/test-inline-2.R
@@ -213,25 +213,22 @@ test_that(".num", {
   })
 })
 
-test_that(".duration formats numeric seconds", {
+test_that(".duration", {
   expect_snapshot({
+    # numeric seconds
     format_inline("--- {.duration 0.042} ---")
     format_inline("--- {.duration 90} ---")
     format_inline("--- {.duration 3661} ---")
+
+    # difftime: units normalised before formatting (not treated as raw seconds)
+    format_inline("{.duration {as.difftime(1.5, units = 'mins')}}")
+    format_inline("{.duration {as.difftime(1, units = 'hours')}}")
   })
 })
 
-test_that(".duration normalises difftime units before formatting", {
-  # difftime stored in non-second units must not be treated as raw seconds
-  dt_mins <- as.difftime(1.5, units = "mins") # 90 seconds
-  expect_equal(format_inline("{.duration {dt_mins}}"), "1m 30s")
-  dt_hours <- as.difftime(1, units = "hours") # 3600 seconds
-  expect_equal(format_inline("{.duration {dt_hours}}"), "1h")
-})
-
-test_that(".time_ago accepts numeric, POSIXct, and POSIXlt inputs", {
+test_that(".time_ago", {
   expect_snapshot({
-    # numeric (unix timestamp)
+    # numeric unix timestamp
     t <- as.numeric(Sys.time() - 120)
     format_inline("{.time_ago {t}}")
 

--- a/tests/testthat/test-inline-2.R
+++ b/tests/testthat/test-inline-2.R
@@ -221,8 +221,11 @@ test_that(".duration", {
     format_inline("--- {.duration 3661} ---")
 
     # difftime: units normalised before formatting (not treated as raw seconds)
-    format_inline("{.duration {as.difftime(1.5, units = 'mins')}}")
-    format_inline("{.duration {as.difftime(1, units = 'hours')}}")
+    dt_mins <- as.difftime(1.5, units = "mins")
+    format_inline("{.duration {dt_mins}}")
+
+    dt_days <- as.difftime(30, units = "days")
+    format_inline("{.duration {dt_days}}")
   })
 })
 

--- a/tests/testthat/test-inline-2.R
+++ b/tests/testthat/test-inline-2.R
@@ -212,3 +212,35 @@ test_that(".num", {
     format_inline("--- {.num {1:4 * 10000}} ---")
   })
 })
+
+test_that(".duration formats numeric seconds", {
+  expect_snapshot({
+    format_inline("--- {.duration 0.042} ---")
+    format_inline("--- {.duration 90} ---")
+    format_inline("--- {.duration 3661} ---")
+  })
+})
+
+test_that(".duration normalises difftime units before formatting", {
+  # difftime stored in non-second units must not be treated as raw seconds
+  dt_mins <- as.difftime(1.5, units = "mins") # 90 seconds
+  expect_equal(format_inline("{.duration {dt_mins}}"), "1m 30s")
+  dt_hours <- as.difftime(1, units = "hours") # 3600 seconds
+  expect_equal(format_inline("{.duration {dt_hours}}"), "1h")
+})
+
+test_that(".time_ago accepts numeric, POSIXct, and POSIXlt inputs", {
+  expect_snapshot({
+    # numeric (unix timestamp)
+    t <- as.numeric(Sys.time() - 120)
+    format_inline("{.time_ago {t}}")
+
+    # POSIXct
+    t <- Sys.time() - 120
+    format_inline("{.time_ago {t}}")
+
+    # POSIXlt
+    t <- as.POSIXlt(Sys.time() - 120)
+    format_inline("{.time_ago {t}}")
+  })
+})


### PR DESCRIPTION
closes #814 
 

``` r
# Downloading a file
start <- proc.time()[[3]]
Sys.sleep(0.1)
elapsed <- proc.time()[[3]] - start
cli::cli_text('Downloaded {.file data.csv} in {.duration {elapsed}}')
#> Downloaded 'data.csv' in 107ms

# Processing step with relative time
last_sync <- Sys.time() - 125
cli::cli_text('Last sync: {.time_ago {last_sync}}')
#> Last sync: 2 minutes ago

# Progress completion
dt <- as.difftime(2.4, units = 'mins')
cli::cli_alert_success('Build completed without errors [{.duration {dt}}]')
#> ✔ Build completed without errors [2m 24s]
```

<sup>Created on 2026-04-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

no new dependencies, was able to use existing formatters.
i wouldve used `pretty_dt` but noted the issue in [in this comment](https://github.com/r-lib/cli/issues/814#issuecomment-4297603916), i could add the missing fxn to the local env and swap out the custom transform
