### PR TITLE
Document progress bar completion messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cli (development version)
 
+* The `cli_progress_bar()` documentation now shows how to leave completion and
+  failure messages on screen with `format_done`, `format_failed`, and
+  `clear = FALSE` (#610).
+
 * `keypress()` improvements:
   - `timeout` argument to wait at most a given number of seconds for a
     key press.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,5 @@
 # cli (development version)
 
-* The `cli_progress_bar()` documentation now shows how to leave completion and
-  failure messages on screen with `format_done`, `format_failed`, and
-  `clear = FALSE` (#610).
-
 * `keypress()` improvements:
   - `timeout` argument to wait at most a given number of seconds for a
     key press.

--- a/R/progress-client.R
+++ b/R/progress-client.R
@@ -216,6 +216,11 @@
 #' like the elapsed time, of the ETA manually. You can also use your own
 #' variables in the calling function:
 #'
+#' To leave a completion or failure message on screen after the progress bar
+#' finishes, set `clear = FALSE` and customize `format_done` and
+#' `format_failed`. The `pb_elapsed` variable is often useful for reporting the
+#' total runtime.
+#'
 #' ```{asciicast progress-format}
 #' #| asciicast_at = "all",
 #' #| asciicast_knitr_output = "svg",
@@ -229,6 +234,9 @@
 #'     format_done = paste0(
 #'       "{col_green(symbol$tick)} Downloaded {pb_total} files ",
 #'       "in {pb_elapsed}."
+#'     ),
+#'     format_failed = paste0(
+#'       "{col_red(symbol$cross)} Download failed after {pb_elapsed}."
 #'     ),
 #'     clear = FALSE,
 #'     total = length(urls)

--- a/man/cli_progress_bar.Rd
+++ b/man/cli_progress_bar.Rd
@@ -337,6 +337,11 @@ are probably useful to avoid calculating some progress bar quantities
 like the elapsed time, of the ETA manually. You can also use your own
 variables in the calling function:
 
+To leave a completion or failure message on screen after the progress bar
+finishes, set \code{clear = FALSE} and customize \code{format_done} and
+\code{format_failed}. The \code{pb_elapsed} variable is often useful for reporting the
+total runtime.
+
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{fun <- function(urls) \{
   cli_progress_bar(
     format = paste0(
@@ -346,6 +351,9 @@ variables in the calling function:
     format_done = paste0(
       "\{col_green(symbol$tick)\} Downloaded \{pb_total\} files ",
       "in \{pb_elapsed\}."
+    ),
+    format_failed = paste0(
+      "\{col_red(symbol$cross)\} Download failed after \{pb_elapsed\}."
     ),
     clear = FALSE,
     total = length(urls)


### PR DESCRIPTION
Fixes #610.

This updates the `cli_progress_bar()` documentation to show how to leave a final success or failure message on screen with `clear = FALSE`, `format_done`, and `format_failed`, including an example that reports `pb_elapsed`.

Checks:
- `Rscript -e 'tools::checkRd("man/cli_progress_bar.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/cli-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests cli_3.6.6.9000.tar.gz`