### PR TITLE
docs: add missing @return tags to exported functions

### DIFF
--- a/R/bullets.R
+++ b/R/bullets.R
@@ -70,7 +70,7 @@ cli_bullets <- function(
 
 #' List of verbatim items
 #'
-#' `cli_format_bullets_raw()` is similar to [cli_bullets()], but it does
+#' `cli_bullets_raw()` is similar to [cli_bullets()], but it does
 #' not perform any inline styling or glue substitutions in the input.
 #'
 #' `format_bullets_raw()` returns the output instead of printing it.

--- a/R/format-conditions.R
+++ b/R/format-conditions.R
@@ -26,6 +26,7 @@
 #' @param message It is formatted via a call to [cli_bullets()].
 #' @param .envir Environment to evaluate the glue expressions in.
 #'
+#' @return A character string containing the formatted message.
 #' @seealso These functions support [inline markup][inline-markup].
 #' @family functions supporting inline markup
 #' @export

--- a/R/ruler.R
+++ b/R/ruler.R
@@ -1,5 +1,7 @@
 #' Print the helpful ruler to the screen
 #'
+#' @return `NULL`, invisibly. Called for its side effect of printing a
+#'   ruler to the screen.
 #' @export
 #' @param width Ruler width.
 #' @examples

--- a/R/simple-theme.R
+++ b/R/simple-theme.R
@@ -60,6 +60,7 @@
 #'   Detection usually works in recent RStudio versions, and in iTerm
 #'   on macOS, but not on other platforms.
 #'
+#' @return A named list that can be used as a cli theme.
 #' @seealso [themes], [builtin_theme()].
 #' @export
 

--- a/R/spark.R
+++ b/R/spark.R
@@ -34,6 +34,7 @@
 #' ```
 #'
 #' @param x A numeric vector between 0 and 1
+#' @return A character string of class `cli_spark_bar` and `cli_spark`.
 #' @export
 #' @seealso [spark_line()]
 
@@ -95,6 +96,7 @@ spark_bar_chars <- function(x, bars = NULL) {
 #' ```
 #'
 #' @inheritParams spark_bar
+#' @return A character string of class `cli_spark_line` and `cli_spark`.
 #' @export
 #' @seealso [spark_bar()]
 

--- a/R/test.R
+++ b/R/test.R
@@ -41,6 +41,8 @@
 #'   * `"all"`: turn on all hyperlinks,
 #'   * `"none"`: turn off all hyperlinks.
 #'
+#' @return The return value of [testthat::test_that()] for the last
+#'   configuration tested (invisibly).
 #' @export
 #' @examples
 #' # testthat cannot record or compare snapshots when you run these

--- a/man/format_error.Rd
+++ b/man/format_error.Rd
@@ -17,6 +17,9 @@ format_message(message, .envir = parent.frame())
 
 \item{.envir}{Environment to evaluate the glue expressions in.}
 }
+\value{
+A character string containing the formatted message.
+}
 \description{
 You can then throw this message with \code{\link[=stop]{stop()}} or \code{rlang::abort()}.
 }

--- a/man/ruler.Rd
+++ b/man/ruler.Rd
@@ -9,6 +9,10 @@ ruler(width = console_width())
 \arguments{
 \item{width}{Ruler width.}
 }
+\value{
+\code{NULL}, invisibly. Called for its side effect of printing a
+ruler to the screen.
+}
 \description{
 Print the helpful ruler to the screen
 }

--- a/man/simple_theme.Rd
+++ b/man/simple_theme.Rd
@@ -12,6 +12,9 @@ background. If \code{"auto"}, then cli will try to detect this.
 Detection usually works in recent RStudio versions, and in iTerm
 on macOS, but not on other platforms.}
 }
+\value{
+A named list that can be used as a cli theme.
+}
 \description{
 To use this theme, you can set it as the \code{cli.theme} option.
 Note that this is in addition to the builtin theme, which is still in

--- a/man/spark_bar.Rd
+++ b/man/spark_bar.Rd
@@ -9,6 +9,9 @@ spark_bar(x)
 \arguments{
 \item{x}{A numeric vector between 0 and 1}
 }
+\value{
+A character string of class \code{cli_spark_bar} and \code{cli_spark}.
+}
 \description{
 Rendered using \href{https://en.wikipedia.org/wiki/Block_Elements}{block elements}.
 In most common fixed width fonts these are rendered wider than regular

--- a/man/spark_line.Rd
+++ b/man/spark_line.Rd
@@ -9,6 +9,9 @@ spark_line(x)
 \arguments{
 \item{x}{A numeric vector between 0 and 1}
 }
+\value{
+A character string of class \code{cli_spark_line} and \code{cli_spark}.
+}
 \description{
 You might want to avoid sparklines on non-UTF-8 systems, because they
 do not look good. You can use \code{\link[=is_utf8_output]{is_utf8_output()}} to test for support

--- a/man/test_that_cli.Rd
+++ b/man/test_that_cli.Rd
@@ -31,6 +31,10 @@ vector with possible hyperlink configurations:
 \item \code{"none"}: turn off all hyperlinks.
 }}
 }
+\value{
+The return value of \code{\link[testthat:test_that]{testthat::test_that()}} for the last
+configuration tested (invisibly).
+}
 \description{
 Use this function in your testthat test files, to test cli output.
 It requires testthat edition 3, and works best with snapshot tests.


### PR DESCRIPTION
## Summary

Adds `@return` roxygen tags and corresponding `\value` Rd sections to 6 exported function families in cli whose generated `.Rd` files lacked `\value` sections. R CMD check --as-cran notes missing `\value` for exported functions; this is also a CRAN submission requirement.

## Changes

### R source files (add `@return` roxygen tags)

| File | Functions | `@return` |
|------|-----------|-----------|
| `R/spark.R` | `spark_bar()`, `spark_line()` | Character string of class `cli_spark_bar`/`cli_spark_line` |
| `R/ruler.R` | `ruler()` | `NULL`, invisibly |
| `R/simple-theme.R` | `simple_theme()` | Named list (theme) |
| `R/format-conditions.R` | `format_error()`, `format_warning()`, `format_message()` | Character string |
| `R/test.R` | `test_that_cli()` | Return value of `testthat::test_that()` |

### Rd files (manually added `\value` sections)

- `man/spark_bar.Rd`, `man/spark_line.Rd`, `man/ruler.Rd`, `man/simple_theme.Rd`, `man/format_error.Rd`, `man/test_that_cli.Rd`

### Bonus fix

- `R/bullets.R`: Fix typo in roxygen comment — `cli_format_bullets_raw()` → `cli_bullets_raw()` (the actual function name)

## Validation

- `tools::checkRd()` on all 6 modified Rd files: **clean** (spark_line.Rd has a pre-existing title-period warning, unrelated)
- `R CMD build --no-build-vignettes`: **succeeds**
- `R CMD check --no-manual --no-vignettes`: **Status OK**
- Tests: **pass**

## Duplicate check

- Open PRs (18 total): none address missing `@return` tags or `\value` documentation
- Open issues: searched "return", "value" — no matching issues