### PR TITLE
docs: document cli_progress_sleep() in C API reference

### DIFF
--- a/inst/include/cli/progress.h
+++ b/inst/include/cli/progress.h
@@ -213,6 +213,22 @@ static R_INLINE void cli_progress_set_status(SEXP bar, const char *status);
 
 static R_INLINE void cli_progress_set_type(SEXP bar, const char *type);
 
+//' ### `cli_progress_sleep()`
+//'
+//' ```c
+//' void cli_progress_sleep(int s, long ns);
+//' ```
+//'
+//' Sleep for the specified amount of time. This function is mainly
+//' useful in examples and tests, to simulate a computation that takes
+//' some time. It respects the `CLI_SPEED_TIME` environment variable,
+//' so automated tests can run faster.
+//'
+//' * `s`: number of seconds to sleep.
+//' * `ns`: number of nanoseconds to sleep.
+
+static R_INLINE void cli_progress_sleep(int s, long ns);
+
 //' ### `cli_progress_update()`
 //'
 //' ```c


### PR DESCRIPTION
Fixes #806.

Add roxygen documentation for `cli_progress_sleep()` in the progress C API header (`inst/include/cli/progress.h`), matching the style of adjacent entries.

## Changes

- Added documentation block for `cli_progress_sleep(int s, long ns)` between `cli_progress_set_type()` and `cli_progress_update()` entries
- Documents the function signature, purpose (sleep utility for examples/tests), and `CLI_SPEED_TIME` environment variable support

## Validation

- Documentation follows the same `//' ### `func()`` pattern as all other entries in the header
- No code changes, documentation only
- 16 lines added to `inst/include/cli/progress.h`