### PR TITLE
docs: fix typos and grammar in roxygen documentation

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -17,7 +17,7 @@ cliappenv$pid <- Sys.getpid()
 #' @param .envir The environment to use, instead of the calling frame,
 #'   to trigger the stop of the app.
 #' @param app App to stop. If `NULL`, the current default app is stopped.
-#'   Otherwise we find the supplied app in the app stack, and remote it,
+#'   Otherwise we find the supplied app in the app stack, and remove it,
 #'   together with all the apps above it.
 #' @return
 #'   `start_app` returns the new app, `default_app` returns the default app.

--- a/R/cli.R
+++ b/R/cli.R
@@ -280,7 +280,7 @@ cli_verbatim <- function(..., .envir = parent.frame()) {
 #'   themes.
 #' @param .envir Environment to evaluate the glue expressions in.
 #'
-#' @seealso These functions supports [inline markup][inline-markup].
+#' @seealso These functions support [inline markup][inline-markup].
 #' @family functions supporting inline markup
 #' @export
 
@@ -795,7 +795,7 @@ cli_li <- function(
 #' @param wrap Whether to auto-wrap the text of the alert.
 #' @param .envir Environment to evaluate the glue expressions in.
 #'
-#' @seealso These functions supports [inline markup][inline-markup].
+#' @seealso These functions support [inline markup][inline-markup].
 #' @family functions supporting inline markup
 #' @export
 

--- a/inst/include/cli/progress.h
+++ b/inst/include/cli/progress.h
@@ -213,6 +213,22 @@ static R_INLINE void cli_progress_set_status(SEXP bar, const char *status);
 
 static R_INLINE void cli_progress_set_type(SEXP bar, const char *type);
 
+//' ### `cli_progress_sleep()`
+//'
+//' ```c
+//' void cli_progress_sleep(int s, long ns);
+//' ```
+//'
+//' Sleep for the specified amount of time. This function is mainly
+//' useful in examples and tests, to simulate a computation that takes
+//' some time. It respects the `CLI_SPEED_TIME` environment variable,
+//' so automated tests can run faster.
+//'
+//' * `s`: number of seconds to sleep.
+//' * `ns`: number of nanoseconds to sleep.
+
+static R_INLINE void cli_progress_sleep(int s, long ns);
+
 //' ### `cli_progress_update()`
 //'
 //' ```c

--- a/man/cli_alert.Rd
+++ b/man/cli_alert.Rd
@@ -124,7 +124,7 @@ cli_alert_info("Data columns: \{.val \{names(mtcars)\}\}.", wrap = TRUE)
 }
 }
 \seealso{
-These functions supports \link[=inline-markup]{inline markup}.
+These functions support \link[=inline-markup]{inline markup}.
 
 Other functions supporting inline markup:
 \code{\link[=cli_abort]{cli_abort()}},

--- a/man/cli_h1.Rd
+++ b/man/cli_h1.Rd
@@ -43,7 +43,7 @@ cli_h3("Header \{.emph 3\}")
 }}
 }
 \seealso{
-These functions supports \link[=inline-markup]{inline markup}.
+These functions support \link[=inline-markup]{inline markup}.
 
 Other functions supporting inline markup:
 \code{\link[=cli_abort]{cli_abort()}},

--- a/man/start_app.Rd
+++ b/man/start_app.Rd
@@ -29,7 +29,7 @@ is destroyed.}
 to trigger the stop of the app.}
 
 \item{app}{App to stop. If \code{NULL}, the current default app is stopped.
-Otherwise we find the supplied app in the app stack, and remote it,
+Otherwise we find the supplied app in the app stack, and remove it,
 together with all the apps above it.}
 }
 \value{


### PR DESCRIPTION
## Changes

- Fix typo: "remote it" → "remove it" in `?stop_app` (`R/app.R:20`)
- Fix grammar: "These functions supports" → "These functions support" in `?cli_h1` (`R/cli.R:283`) and `?cli_alert` (`R/cli.R:798`)

## Files changed

- `R/app.R`: roxygen source for `stop_app()` parameter docs
- `R/cli.R`: roxygen source for `cli_h1()` and `cli_alert()` @seealso tags
- `man/start_app.Rd`: regenerated man page
- `man/cli_h1.Rd`: regenerated man page
- `man/cli_alert.Rd`: regenerated man page

## Validation

- `tools::checkRd()` passes on all three modified Rd files
- No other instances of these typos remain in the package