### PR TITLE
Fix VT segment numbering

### DIFF
--- a/R/vt.R
+++ b/R/vt.R
@@ -76,7 +76,7 @@ vt_output <- function(output, width = 80L, height = 25L) {
     data.frame(
       stringsAsFactors = FALSE,
       lineno = i,
-      segmentno = seq_along(segments),
+      segmentno = seq_along(segs),
       segment = segs,
       bold = grepl("bold;", lgs$values, fixed = TRUE),
       italic = grepl("italic;", lgs$values, fixed = TRUE),

--- a/tests/testthat/_snaps/vt.md
+++ b/tests/testthat/_snaps/vt.md
@@ -54,10 +54,10 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1                   12 FALSE  FALSE     FALSE         FALSE
-      2      1         1                   34 FALSE  FALSE     FALSE         FALSE
-      3      1         1                   56  TRUE  FALSE     FALSE         FALSE
-      4      1         1                   78  TRUE  FALSE     FALSE         FALSE
-      5      1         1         90           FALSE  FALSE     FALSE         FALSE
+      2      1         2                   34 FALSE  FALSE     FALSE         FALSE
+      3      1         3                   56  TRUE  FALSE     FALSE         FALSE
+      4      1         4                   78  TRUE  FALSE     FALSE         FALSE
+      5      1         5         90           FALSE  FALSE     FALSE         FALSE
       6      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -74,7 +74,7 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1             I'm bold  TRUE  FALSE     FALSE         FALSE
-      2      1         1                      FALSE  FALSE     FALSE         FALSE
+      2      1         2                      FALSE  FALSE     FALSE         FALSE
       3      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -88,7 +88,7 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1           I'm italic FALSE   TRUE     FALSE         FALSE
-      2      1         1                      FALSE  FALSE     FALSE         FALSE
+      2      1         2                      FALSE  FALSE     FALSE         FALSE
       3      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -102,7 +102,7 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1       I'm underlined FALSE  FALSE      TRUE         FALSE
-      2      1         1                      FALSE  FALSE     FALSE         FALSE
+      2      1         2                      FALSE  FALSE     FALSE         FALSE
       3      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -116,7 +116,7 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1    I'm strikethrough FALSE  FALSE     FALSE          TRUE
-      2      1         1                      FALSE  FALSE     FALSE         FALSE
+      2      1         2                      FALSE  FALSE     FALSE         FALSE
       3      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -130,7 +130,7 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1          I'm inverse FALSE  FALSE     FALSE         FALSE
-      2      1         1                      FALSE  FALSE     FALSE         FALSE
+      2      1         2                      FALSE  FALSE     FALSE         FALSE
       3      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE    TRUE  <NA>             <NA> <NA>        <NA>
@@ -145,8 +145,8 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1                 pre  FALSE  FALSE     FALSE         FALSE
-      2      1         1                 text FALSE  FALSE     FALSE         FALSE
-      3      1         1          post        FALSE  FALSE     FALSE         FALSE
+      2      1         2                 text FALSE  FALSE     FALSE         FALSE
+      3      1         3          post        FALSE  FALSE     FALSE         FALSE
       4      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>
@@ -162,8 +162,8 @@
     Output
         lineno segmentno              segment  bold italic underline strikethrough
       1      1         1                 pre  FALSE  FALSE     FALSE         FALSE
-      2      1         1                 text FALSE  FALSE     FALSE         FALSE
-      3      1         1          post        FALSE  FALSE     FALSE         FALSE
+      2      1         2                 text FALSE  FALSE     FALSE         FALSE
+      3      1         3          post        FALSE  FALSE     FALSE         FALSE
       4      2         1                      FALSE  FALSE     FALSE         FALSE
         blink inverse color background_color link link_params
       1 FALSE   FALSE  <NA>             <NA> <NA>        <NA>

--- a/tests/testthat/test-vt.R
+++ b/tests/testthat/test-vt.R
@@ -64,6 +64,12 @@ test_that_cli(configs = "ansi", "ANSI SGR", {
   )
 })
 
+test_that("segments are numbered within each line", {
+  output <- vt_output("a\033[31mb\033[32mc", width = 3, height = 1)
+
+  expect_equal(output$segmentno, 1:3)
+})
+
 test_that("hyperlinks", {
   withr::local_options(cli.hyperlink = TRUE)
   expect_snapshot({


### PR DESCRIPTION
Inside `segments <- lapply(...)`, the callback does `segmentno = seq_along(segments)`. At that point the local `segments` binding does not exist yet, so the symbol resolves to `graphics::segments` (a closure), and `seq_along(<closure>)` is `1`. The `segmentno` column is therefore always `1` instead of `1..n`.

Found with https://github.com/sims1253/ry :)