### PR TITLE
hash: validate raw helper size arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@
   cli progress bars. It makes cli redraw the progress bar for every
   progress update.
 
+* `hash_raw_animal()` and `hash_raw_emoji()` now validate `n_adj` and `size`,
+  respectively, consistently with their character-vector variants. This also
+  affects `hash_obj_animal()` and `hash_obj_emoji()` (#834, @fly1d).
+
 # cli 3.6.6
 
 * New `{.num}` and `{.bytes}` inline styles to format numbers

--- a/R/hash.R
+++ b/R/hash.R
@@ -348,7 +348,11 @@ hash_emoji1_transform <- function(md5, size) {
 #' * `names`: names of the emojis, in a character vector.
 
 hash_raw_emoji <- function(x, size = 3) {
-  stopifnot(is.raw(x))
+  stopifnot(
+    is.raw(x),
+    is_count(size),
+    size >= 1 && size <= 4
+  )
   md5 <- hash_raw_md5(x)
   emo <- hash_emoji1_transform(md5, size)
 
@@ -492,7 +496,11 @@ hash_animal1_transform <- function(md5, n_adj) {
 #' * `words: the adjectives and the animal name in a character vector.
 
 hash_raw_animal <- function(x, n_adj = 2) {
-  stopifnot(is.raw(x))
+  stopifnot(
+    is.raw(x),
+    is_count(n_adj),
+    n_adj >= 0 && n_adj <= 3
+  )
   md5 <- hash_raw_md5(x)
   hash <- hash_animal1_transform(md5, n_adj)
 

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -165,6 +165,16 @@ test_that("hash_obj_emoji", {
   })
 })
 
+test_that("emoji hash size is validated for raw vectors and objects", {
+  expect_no_error(hash_raw_emoji(raw(), size = 1))
+  expect_no_error(hash_raw_emoji(raw(), size = 4))
+  expect_error(hash_raw_emoji(raw(), size = 0), class = "simpleError")
+  expect_error(hash_raw_emoji(raw(), size = 1.5), class = "simpleError")
+  expect_error(hash_raw_emoji(raw(), size = 5), class = "simpleError")
+  expect_error(hash_obj_emoji(NULL, size = 0), class = "simpleError")
+  expect_error(hash_obj_emoji(NULL, size = 5), class = "simpleError")
+})
+
 test_that("hash_animal", {
   expect_snapshot({
     hash_animal(character())$words
@@ -191,6 +201,16 @@ test_that("hash_obj_animal", {
     hash_obj_animal(1:10)$words
     hash_obj_animal(mtcars)$words
   })
+})
+
+test_that("animal hash adjective count is validated for raw vectors and objects", {
+  expect_no_error(hash_raw_animal(raw(), n_adj = 0))
+  expect_no_error(hash_raw_animal(raw(), n_adj = 3))
+  expect_error(hash_raw_animal(raw(), n_adj = -1), class = "simpleError")
+  expect_error(hash_raw_animal(raw(), n_adj = 1.5), class = "simpleError")
+  expect_error(hash_raw_animal(raw(), n_adj = 4), class = "simpleError")
+  expect_error(hash_obj_animal(NULL, n_adj = -1), class = "simpleError")
+  expect_error(hash_obj_animal(NULL, n_adj = 4), class = "simpleError")
 })
 
 test_that("hash_xxhash", {


### PR DESCRIPTION
## Summary

- apply the existing count and range checks to `hash_raw_emoji()` and `hash_raw_animal()`
- make the object variants inherit the same validation through their raw helpers
- add regression coverage for valid boundaries, out-of-range values, and fractional values

Fixes #834.

## Verification

- `testthat::test_local(filter = "hash", reporter = "silent")` - 53 passed, 0 failures, 0 errors, 0 warnings, 0 skips
- `air format R/hash.R tests/testthat/test-hash.R`
- `R CMD build --no-manual`
- `R CMD check --no-manual` on the source tarball - `Status: OK`

## AI assistance

OpenAI Codex (GPT-5) assisted with implementation, tests, and verification.